### PR TITLE
ea_vecnorm introduced and used

### DIFF
--- a/dependency/ea_vecnorm.m
+++ b/dependency/ea_vecnorm.m
@@ -1,0 +1,16 @@
+function nx=ea_vecnorm(x,p)
+% Vector / matrix norm.
+% This is a work-around for missing `vecnorm` function prior Matlab 2017b.
+
+if nargin<2
+    p=2;
+end
+
+if isvector(x)
+    nx=norm(x,p);
+else
+    nx=x;
+    for i=1:size(x,2)
+        nx(:,i)=norm(x(:,i),p);
+    end
+end

--- a/ea_genvat_horn.m
+++ b/ea_genvat_horn.m
@@ -703,12 +703,6 @@ fact = (ea_vecnorm(cr_pos([1 3],:),2)-elspec.lead_diameter/2)./ea_vecnorm(cr_pos
 cr_pos([1 3],:) = cr_pos([1 3],:).*fact;
 cr_pos(:,fact<0) = nan;
 
-size('r_pos')
-size(r_pos)
-size('r_pos(:,r_pos(2,:)>0)')
-size(r_pos(:,r_pos(2,:)>0))
-size('cr_pos')
-size(cr_pos)
 r_pos(:,r_pos(2,:)>0) = cr_pos;
 artpts = find(isnan(r_pos(1,:)));
 

--- a/ea_genvat_horn.m
+++ b/ea_genvat_horn.m
@@ -673,8 +673,8 @@ oldlocas = vat.pos;
 
 % Assign tip of electrode as origin
 org = elstruct.trajectory{1,side}(1,:);
-tra = elstruct.trajectory{1,side} - org;
-pos = vat.pos - org;
+tra = elstruct.trajectory{1,side} - repmat(org,size(elstruct.trajectory{1,side},1),1);
+pos = vat.pos - repmat(org,size(vat.pos,1),1);
 
 % Rotate coordinate system so that y-axis aligns with electrode
 elvec = (tra(end,:))';
@@ -699,10 +699,16 @@ end
 r_pos = R*pos';
 
 cr_pos = r_pos(:,r_pos(2,:)>0); % Determine all points at electrode level
-fact = (vecnorm(cr_pos([1 3],:),2)-elspec.lead_diameter/2)./vecnorm(cr_pos([1 3],:),2); % Determine shifting factors
+fact = (ea_vecnorm(cr_pos([1 3],:),2)-elspec.lead_diameter/2)./ea_vecnorm(cr_pos([1 3],:),2); % Determine shifting factors
 cr_pos([1 3],:) = cr_pos([1 3],:).*fact;
 cr_pos(:,fact<0) = nan;
 
+size('r_pos')
+size(r_pos)
+size('r_pos(:,r_pos(2,:)>0)')
+size(r_pos(:,r_pos(2,:)>0))
+size('cr_pos')
+size(cr_pos)
 r_pos(:,r_pos(2,:)>0) = cr_pos;
 artpts = find(isnan(r_pos(1,:)));
 
@@ -728,7 +734,7 @@ vat.ET(artpts) = [];
 
 oldlocas(artpts,:) = [];
 
-moved = vecnorm(vat.pos-oldlocas',2);
+moved = ea_vecnorm(vat.pos-oldlocas',2);
 moved(moved<0.2) = [];
 moved = abs(moved-elspec.lead_diameter/2);
 


### PR DESCRIPTION
ea_vecnorm workaround for missing `vecnorm` in Matlab <R2017b