### PR TITLE
No toolboxes needed for Refined TRAC/CORE

### DIFF
--- a/dependency/ea_findpeaks.m
+++ b/dependency/ea_findpeaks.m
@@ -1,0 +1,14 @@
+function [pks, locs, varargout] = ea_findpeaks(data, varargin)
+
+has_findpeaks = ~isempty(which('has_findpeaks'));
+if has_findpeaks
+    [pks, locs, w, p] = findpeaks(data, varargin{:});
+    varargout = {w, p};
+else
+    slope_sign = sign(diff(data));
+    locs = 1 + find(slope_sign(1:end-1) > 0 & slope_sign(2:end) < 0);
+    if ~isempty(varargin) && strcmpi(varargin{1}, 'NPeaks')
+        locs = locs(1:varargin{2});
+    end
+    pks = data(locs);
+end

--- a/dependency/ea_sgolayfilt.m
+++ b/dependency/ea_sgolayfilt.m
@@ -1,0 +1,65 @@
+function y = ea_sgolayfilt(x, order, framelen, weights, dim)
+% varargin: x, order, framelen, weights, dim
+
+has_sgolayfilt = ~isempty(which('sgolayfilt'));
+if has_sgolayfilt
+    if nargin < 4
+        y = sgolayfilt(x, order, framelen);
+    elseif nargin < 5
+        y = sgolayfilt(x, order, framelen, weights);
+    else
+        y = sgolayfilt(x, order, framelen, dim);
+    end
+else
+    % Reimplementation from scipy version
+    % https://github.com/scipy/scipy/blob/v0.17.1/scipy/signal/_savitzky_golay.py#L228-L349
+    if nargin > 3
+        warning('`weights` ignored.');
+    end
+    if nargin < 5 || isempty(dim)
+        dim = ndims(x);
+    end
+    deriv = 0;
+    delta = 1.0;
+    
+    %coeffs = savgol_coeffs(framelen, order, deriv, delta);
+    if order >= framelen
+        error('order must be less than framelen');
+    end
+    
+    if mod(framelen, 2) == 0
+        error('framelen must be odd.');
+    end
+    
+    halflen = (framelen - 1) / 2;
+    design_cols = (-halflen:framelen - halflen - 1);
+    design_cols = flip(design_cols)';
+    design_rows = (0:order);
+    design_mat = design_cols .^ design_rows;
+    design_mat = design_mat';
+    
+    % z determines which order derivative is returned.
+    z = zeros(order + 1, 1);
+    % The coefficient assigned to z[deriv] scales the result to take into
+    % account the order of the derivative and the sample spacing.
+    z(deriv + 1) = factorial(deriv) / (delta .^ deriv);
+    
+    % Find the least-squares solution of design_mat*coeffs = z
+    % coeffs = design_mat' \ z;
+    coeffs = lsqminnorm(design_mat, z);
+            
+    %savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
+    %              axis=-1, mode='interp', cval=0.0)
+    % y = convolve1d(x, coeffs, axis=axis, mode="constant")
+    y = zeros(size(x));
+    for col_ix = 1:size(x, 2)
+        y(:, col_ix) = conv(x(:, col_ix), coeffs, 'same');
+        
+        poly_coeffs = polyfit((1:framelen), x(1:framelen, col_ix)', order);
+        y(1:halflen, col_ix) = polyval(poly_coeffs, (1:halflen)) / (delta .^ deriv);
+        
+        poly_coeffs = polyfit((1:framelen), x(end-framelen+1:end, col_ix)', order);
+        interp_x = (framelen - halflen:framelen - 1);
+        y(end-halflen+1:end, col_ix) = polyval(poly_coeffs, interp_x) / (delta .^ deriv);
+    end
+end

--- a/ea_refinecoords.m
+++ b/ea_refinecoords.m
@@ -92,12 +92,12 @@ function [coords_mm,trajectory,markers] = ea_refinecoords(options)
         end
 
         % filter and find first peak (head fiducial marker)
-        filtered_max = sgolayfilt(max(b, [], 2), 1, 21);
+        filtered_max = ea_sgolayfilt(max(b, [], 2), 1, 21);
         if (deltaz < 0) % sometimes the slice is upside down
             filtered_max = flipud(filtered_max);
         end
 
-        [~, idy] = findpeaks(filtered_max, 'NPeaks', 1);
+        [~, idy] = ea_findpeaks(filtered_max, 'NPeaks', 1);
         if isempty(idy)
             warning(['Could not find head of electrode. Check trajectory. Skipping side ', num2str(side)]);
             continue;


### PR DESCRIPTION
`ea_sgolayfilt` uses signal processing toolbox if available, otherwise it falls back to an algorithm that is a port of scipy's algorithm. I compared the results with scipy and the output was identical. I did not compare the results with `sgolayfilt` because I don't have it!

`ea_findpeaks` uses `findpeaks` if signal processing toolbox is available, otherwise it uses a terribly simple algorithm.

These functions are now called in `ea_refinecoords`, so it's possible to do DBS electrode reconstruction without any toolboxes if the user selects Refined TRAC/CORE.

* I need help testing ea_findpeaks by somebody who has the signal processing toolbox. Did I pass the arguments and returns through correctly? Probably not.
* My alternative findpeaks algorithm is quite stupid. I think this works for this scenario because `ea_refinecoords` previously called `findpeaks` with default settings, and from reading the docs it seems like at default settings all it does is look for samples where the previous and next sample were lower. `findpeaks` is also called in PaCER and `ea_reconstruct_trajectory` with different arguments that would need to be accommodated if they were to use `ea_findpeaks`.
