### PR TITLE
Update ea_apply_normalization_tofile.m

### DIFF
--- a/ea_apply_normalization_tofile.m
+++ b/ea_apply_normalization_tofile.m
@@ -58,6 +58,7 @@ switch ea_whichnormmethod(directory)
         ea_fsl_apply_normalization(options,from,to,useinverse,refim,'',interp);
 
     otherwise % SPM part here
+        tempdir = pwd;% ensure using a writable folder (not necessarily tempdir)
         for fi=1:length(from) % assume from and to have same length (must have for this to work)
             if strcmp(from{fi}(end-2:end),'.gz') % .gz support
                 wasgz = 1;


### PR DESCRIPTION
for SPM normalization tempdir is not defined.
This can be the current directory (so that the folder is always writable as suggested in the file) or "tmp=ea_getleadtempdir;" but may not always be writable/work.