### PR TITLE
Update ea_ft_deterministictracking_kroon.m

### DIFF
--- a/connectomics/ea_ft_deterministictracking_kroon.m
+++ b/connectomics/ea_ft_deterministictracking_kroon.m
@@ -90,7 +90,7 @@ fibers=ea_FT(FA,VectorF,Xmask,parametersFT);
 save([options.root,options.patientname,filesep,options.prefs.FTR_unnormalized],'fibers');
 
 %% export .trk copy for trackvis visualization
-ea_b0ftr2trk([directory,options.prefs.FTR_unnormalized],[directory,options.prefs.b0]); % export unnormalized ftr to .trk
+ea_ftr2trk([directory,options.prefs.FTR_unnormalized],[directory,options.prefs.b0]); % export unnormalized ftr to .trk
 disp('Done.');
 
 %% add methods dump:


### PR DESCRIPTION
Line 93: when running individual tractography I get an error because the function "ea_b0ftr2trk" does not exist.
There is one function called "ea_ftr2trk". Should call this be changed to use this function?