### PR TITLE
Bugfix/workaround for fslhd on the windows platform

### DIFF
--- a/ext_libs/fsl/ea_fslhd.m
+++ b/ext_libs/fsl/ea_fslhd.m
@@ -22,7 +22,34 @@ cmd = [FSLHD, ' ', xmlarg, ' ', input, ];
 if ~ispc
     [~, cmdout] = system(['bash -c "', cmd, '"']);
 else
+    % If it ends in .gz, needs to be extracted.
+    % This is because the compiled version of fslhd.exe for windows 
+    % does not read gunzipped nifti files
+    % I prefer to unzip in place, just assumng that if there is
+    % already an unzipped nifti, I can use that instead for speed
+    file_path=strrep(input,'"','');
+    file_ext=file_path(end-2:end);
+    was_nii_unzipped=false;
+    if strcmp(file_ext,'.gz')
+        file_path_unzipped=strrep(file_path,'.gz','');
+        if exist(file_path_unzipped,'file')>0
+            was_nii_unzipped=true;
+        else
+            %if it did not already exist, un(gun)zip it
+            gunzip(file_path);
+        end
+        %remove the extension .gz from the input path
+        input=strrep(input,'.gz','');
+        cmd = [FSLHD, ' ', xmlarg, ' ', input, ];
+    end
     [~, cmdout] = system(cmd);
+    
+    if strcmp(file_ext,'.gz')
+        if ~was_nii_unzipped
+            %delete this temporarily extracted file
+            delete(file_path_unzipped);
+        end
+    end
 end
 
 % Trim string


### PR DESCRIPTION
The compiled version of fslhd for windows does not read the nifti header if it is gunzipped (*.nii.gz). As workaround, the wrapper will un(gun)zip the nifti file (only on windows), read the header, and delete the unzipped file if necessary.