### PR TITLE
ENH: atlas display patch using ea_roi

### DIFF
--- a/classes/ea_roi/ea_roi.m
+++ b/classes/ea_roi/ea_roi.m
@@ -181,7 +181,7 @@ classdef ea_roi < handle
                 evtnm='all';
             end
             if isempty(obj.patchH)
-                                obj.patchH=patch;
+                obj.patchH=patch;
             end
             if ismember(evtnm,{'all','threshold','smooth','hullsimplify','usesolidcolor'}) % need to recalc fv here:
                 bb=[0,0,0;size(obj.nii.img)];

--- a/classes/ea_roi/ea_roi.m
+++ b/classes/ea_roi/ea_roi.m
@@ -70,14 +70,12 @@ classdef ea_roi < handle
                 catch
                     [~,obj.name]=fileparts(obj.niftiFilename);
                 end
-                
-                obj.plotFigureH=gcf;
-                
-                if exist('pobj','var') && ~isempty(pobj)
-                    try
-                        obj.plotFigureH=pobj.plotFigureH;
-                    end
+                try
+                    obj.plotFigureH=pobj.plotFigureH;
+                catch
+                    obj.plotFigureH=gcf;
                 end
+
                 try
                     obj.htH=pobj.htH;
                 catch
@@ -141,7 +139,8 @@ classdef ea_roi < handle
                 
                 
                 update_roi(obj);
-                breathelife(obj);
+                    breathelife(obj);
+                
             end
             
             
@@ -152,29 +151,31 @@ classdef ea_roi < handle
         end
         
         function breathelife(obj)
-            addlistener(obj,'Visible','PostSet',...
-                @changeevent);
-            addlistener(obj,'color','PostSet',...
-                @changeevent);
-            addlistener(obj,'usesolidcolor','PostSet',...
-                @changeevent);
-            addlistener(obj,'threshold','PostSet',...
-                @changeevent);
-            addlistener(obj,'smooth','PostSet',...
-                @changeevent);
-            addlistener(obj,'hullsimplify','PostSet',...
-                @changeevent);
-            addlistener(obj,'alpha','PostSet',...
-                @changeevent);
-            if isempty(obj.toggleH)
-                                obj.toggleH=uitoggletool(obj.htH);
-            end
-            
-            % Get the underlying java object using findobj
-            jtoggle = findjobj(obj.toggleH);
-            % Specify a callback to be triggered on any mouse release event
-            set(jtoggle, 'MouseReleasedCallback', {@rightcallback,obj})
-            setappdata(obj.plotFigureH,'addht',obj.htH);
+                addlistener(obj,'Visible','PostSet',...
+                    @changeevent);
+                addlistener(obj,'color','PostSet',...
+                    @changeevent);
+                addlistener(obj,'usesolidcolor','PostSet',...
+                    @changeevent);
+                addlistener(obj,'threshold','PostSet',...
+                    @changeevent);
+                addlistener(obj,'smooth','PostSet',...
+                    @changeevent);
+                addlistener(obj,'hullsimplify','PostSet',...
+                    @changeevent);
+                addlistener(obj,'alpha','PostSet',...
+                    @changeevent);
+                if isempty(obj.toggleH)
+                    obj.toggleH=uitoggletool(obj.htH);
+                end
+                if strcmp(obj.plotFigureH.Visible,'on') % only make GUI functioning if figure is visible.
+                    
+                    % Get the underlying java object using findobj
+                    jtoggle = findjobj(obj.toggleH);
+                    % Specify a callback to be triggered on any mouse release event
+                    set(jtoggle, 'MouseReleasedCallback', {@rightcallback,obj})
+                end
+                setappdata(obj.plotFigureH,'addht',obj.htH);
         end
         function obj=update_roi(obj,evtnm) % update ROI
             if ~exist('evtnm','var')

--- a/classes/ea_roi/ea_roi.m
+++ b/classes/ea_roi/ea_roi.m
@@ -68,20 +68,26 @@ classdef ea_roi < handle
             else
                 obj.color = ea_uisetcolor;
             end
-
-            % load nifti
-            obj.nii=ea_load_nii(obj.niftiFilename);
-            obj.nii.img(obj.nii.img==0) = nan;
-            obj.nii.img(isinf(obj.nii.img)) = nan;
-            if length(unique(obj.nii.img(~isnan(obj.nii.img))))==1
-                obj.binary=1;
-            else
-                obj.nii.img=obj.nii.img-nanmin(obj.nii.img(:)); % set min to zero
-                obj.binary=0;
+            try
+                obj.nii=pobj.nii;
+            catch
+                % load nifti
+                obj.nii=ea_load_nii(obj.niftiFilename);
+                obj.nii.img(obj.nii.img==0) = nan;
+                obj.nii.img(isinf(obj.nii.img)) = nan;
+                
+                if length(unique(obj.nii.img(~isnan(obj.nii.img))))==1
+                    obj.binary=1;
+                else
+                    obj.nii.img=obj.nii.img-nanmin(obj.nii.img(:)); % set min to zero
+                    obj.binary=0;
+                end
+                obj.nii.img(isnan(obj.nii.img)) = 0;
+                obj.nii.img(isinf(obj.nii.img)) = 0;
             end
-            obj.nii.img(isnan(obj.nii.img)) = 0;
-            obj.nii.img(isinf(obj.nii.img)) = 0;
             options.prefs=ea_prefs;
+            
+            if ~isnan(obj.nii)
             obj.max=ea_nanmax(obj.nii.img(~(obj.nii.img==0)));
             obj.min=ea_nanmin(obj.nii.img(~(obj.nii.img==0)));
             maxmindiff=obj.max-obj.min;

--- a/classes/ea_roi/ea_roicontrol.m
+++ b/classes/ea_roi/ea_roicontrol.m
@@ -192,9 +192,9 @@ function showhide_Callback(hObject, eventdata, handles)
 obj=getappdata(handles.roicontrol,'obj');
 switch get(hObject,'Value')
     case 1
-obj.visible='on';
+obj.Visible='on';
     case 0
-   obj.visible='off';
+   obj.Visible='off';
 end
 
 

--- a/classes/ea_trajectory/ea_trajectory.m
+++ b/classes/ea_trajectory/ea_trajectory.m
@@ -175,26 +175,27 @@ classdef ea_trajectory < handle
             update_trajectory(obj);
 
             % Get the underlying java object using findobj
-            jtoggle = findjobj(obj.toggleH);
-
-            % Specify a callback to be triggered on any mouse release event
-            set(jtoggle, 'MouseReleasedCallback', {@rightcallback,obj})
-            addlistener(obj, 'showPlanning', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'hasPlanning', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'elmodel', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'showMacro', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'showMicro', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'relateMicro', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'color', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'target', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'alpha', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'target', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'planRelative', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'colorMacroContacts', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'planningAppearance', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'plan2elstruct_model', 'PostSet', @ea_trajectory.changeevent);
-            addlistener(obj, 'electrodeRelativeToPlan', 'PostSet', @ea_trajectory.changeevent);
-
+            if strcmp(obj.plotFigureH.Visible,'on') % only needed if figure is really visible (when calling from lead group it could be hidden).
+                jtoggle = findjobj(obj.toggleH);
+                
+                % Specify a callback to be triggered on any mouse release event
+                set(jtoggle, 'MouseReleasedCallback', {@rightcallback,obj})
+                addlistener(obj, 'showPlanning', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'hasPlanning', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'elmodel', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'showMacro', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'showMicro', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'relateMicro', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'color', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'target', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'alpha', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'target', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'planRelative', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'colorMacroContacts', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'planningAppearance', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'plan2elstruct_model', 'PostSet', @ea_trajectory.changeevent);
+                addlistener(obj, 'electrodeRelativeToPlan', 'PostSet', @ea_trajectory.changeevent);
+            end
             if (exist('pobj','var') && isfield(pobj,'openedit') && pobj.openedit) || ~exist('pobj','var')
                 obj.controlH = ea_trajectorycontrol(obj);
             end

--- a/ea_atlasselect.m
+++ b/ea_atlasselect.m
@@ -339,8 +339,8 @@ for branch=1:length(sels.branches)
 
                 [ixs,ixt]=ea_getsubindex(h.sgsub{branch}{leaf}.toString,sidec,h.atlassurfs,h.togglebuttons,h.uselabelname,h.atlases);
                 if strcmp(sels.sides{branch}{leaf}{side},'selected')
-                    if ~strcmp(h.atlassurfs(ixs).Visible,'on')
-                        h.atlassurfs(ixs).Visible='on';
+                    if ~strcmp(h.atlassurfs{ixs}.Visible,'on')
+                        h.atlassurfs{ixs}.Visible='on';
                         h.togglebuttons(ixt).State='on';
                     end
 
@@ -348,8 +348,8 @@ for branch=1:length(sels.branches)
                         h.atlaslabels(ixs).Visible='on';
                     end
                 elseif strcmp(sels.sides{branch}{leaf}{side},'not selected')
-                    if ~strcmp(h.atlassurfs(ixs).Visible,'off')
-                        h.atlassurfs(ixs).Visible='off';
+                    if ~strcmp(h.atlassurfs{ixs}.Visible,'off')
+                        h.atlassurfs{ixs}.Visible='off';
                         h.togglebuttons(ixt).State='off';
                     end
 
@@ -587,19 +587,19 @@ for branch=1:length(sels.branches)
             [ixs,ixt]=ea_getsubindex(h.sgsub{branch}{leaf}.toString,sidec,h.atlassurfs,h.togglebuttons,h.uselabelname,h.atlases);
 
             if ismember(char(h.sgsubfi{branch}{leaf}),onatlasnames)
-                h.atlassurfs(ixs).Visible='on';
+                h.atlassurfs{ixs}.Visible='on';
                 if strcmp(h.labelbutton.State, 'on')
                     h.atlaslabels(ixs).Visible='on';
                 end
                 h.togglebuttons(ixt).State='on';
             elseif ismember(char(h.sgsubfi{branch}{leaf}),offatlasnames)
-                h.atlassurfs(ixs).Visible='off';
+                h.atlassurfs{ixs}.Visible='off';
                 h.atlaslabels(ixs).Visible='off';
                 h.togglebuttons(ixt).State='off';
             else % not explicitly mentioned
                 switch preset.default
                     case 'absolute'
-                        h.atlassurfs(ixs).Visible='off';
+                        h.atlassurfs{ixs}.Visible='off';
                         h.atlaslabels(ixs).Visible='off';
                         h.togglebuttons(ixt).State='off';
                     case 'relative'

--- a/ea_elvis.m
+++ b/ea_elvis.m
@@ -369,29 +369,6 @@ if options.d3.writeatlases && ~strcmp(options.atlasset, 'Use none')
         ea_openatlascontrol([],[],atlases,resultfig,options);
     end
 
-    if options.d3.elrendering==1 && options.d3.exportBB % export vizstruct for lateron export to JSON file / Brainbrowser.
-        try % see if electrode has been defined.
-            cnt=length(vizstruct);
-        catch
-            cnt=0;
-        end
-        % export vizstruct
-        try
-            for side=1:length(options.sides)
-                for atl=1:length(atlases.fv)
-                    if isfield(atlases.fv{atl,side},'faces')
-                        vizstruct(cnt+1).faces=atlases.fv{atl,side}.faces;
-                        vizstruct(cnt+1).vertices=atlases.fv{atl,side}.vertices;
-                        vizstruct(cnt+1).normals=atlases.normals{atl,side};
-                        vizstruct(cnt+1).colors=[...
-                            squeeze(ind2rgb(round(atlases.cdat{atl,side}),atlases.colormap)),...
-                            repmat(0.7,size(atlases.normals{atl,side},1),1)];
-                        cnt=cnt+1;
-                    end
-                end
-            end
-        end
-    end
 else
     colormap(gray)
 end

--- a/ea_genatlastable.m
+++ b/ea_genatlastable.m
@@ -26,7 +26,7 @@ else
     mifix='';
 end
 
-if isempty(atlases) || ~isfield(atlases,'roi') % old format
+if isempty(atlases)
     disp('Generating Atlas table. This may take a while...');
 
     lhcell=cell(0); rhcell=cell(0); mixedcell=cell(0); midlinecell=cell(0);
@@ -184,6 +184,7 @@ if checkrebuild(atlases,options,root,mifix)
                     ea_addnii2lf(atlases,atlas,structure.nii.img,options,root,mifix)
                    
                     iroi{atlas,side}=structure; % later stored
+                    ifv{atlas,side} = [];
                     ipixdim{atlas,side}=structure.nii.voxsize(1:3); % later stored
                     iXYZ{atlas,side}=XYZ; % later stored
                     try
@@ -258,6 +259,10 @@ if checkrebuild(atlases,options,root,mifix)
         try        atlases.roi=iroi; end
         atlases.version=2; % crude versioning introduced (anything without a version tag is considered version 1).
         atlases.rebuild=0; % always reset rebuild flag.
+        try atlases=rmfield(atlases,'cdat'); end % redundancy cleanup
+        try atlases=rmfield(atlases,'colorc'); end % redundancy cleanup
+        try atlases=rmfield(atlases,'normals'); end % redundancy cleanup
+
         save([root,filesep,mifix,options.atlasset,filesep,'atlas_index.mat'],'atlases','-v7.3');
     end
 end

--- a/ea_showatlas.m
+++ b/ea_showatlas.m
@@ -163,9 +163,9 @@ for nativemni=nm % switch between native and mni space atlases.
                     try
                         if isfield(atlases.XYZ{atlas,side},'val') % volumetric atlas
                             thresh=ea_detthresh(atlases,atlas,atlases.XYZ{atlas,side}.val);
-                            atsearch=KDTreeSearcher(XYZ.mm(XYZ.val>thresh,:));
+                            atsearch=KDTreeSearcher(atlases.XYZ{atlas,side}.mm(atlases.XYZ{atlas,side}.val>thresh,:));
                         else % fibertract
-                            atsearch=KDTreeSearcher(XYZ.mm(:,1:3));
+                            atsearch=KDTreeSearcher(atlases.XYZ{atlas,side}.mm(:,1:3));
                         end
 
                         for el=1:length(elstruct)
@@ -176,12 +176,12 @@ for nativemni=nm % switch between native and mni space atlases.
                             Dh=D;
 
                             try
-                                in=inhull(ea_stats.electrodes(el).coords_mm{side},fv.vertices,fv.faces,1.e-13*mean(abs(fv.vertices(:))));
+                                in=inhull(ea_stats.electrodes(el).coords_mm{side},atlases.roi{atlas,side}.fv.vertices,atlases.roi{atlas,side}.fv.faces,1.e-13*mean(abs(atlases.roi{atlas,side}.fv.vertices(:))));
                                 Dh(in)=0;
                             end
                             ea_stats.conmat_inside_hull{el,side}(:,atlas)=Dh;
 
-                            D(D<mean(pixdim))=0; % using mean here but assuming isotropic atlases in general..
+                            D(D<mean(atlases.pixdim{atlas,side}))=0; % using mean here but assuming isotropic atlases in general..
                             ea_stats.conmat_inside_vox{el,side}(:,atlas)=D;
                         end
                     catch

--- a/helpers/ea_reorderatlas.m
+++ b/helpers/ea_reorderatlas.m
@@ -1,15 +1,17 @@
 function atlases=ea_reorderatlas(atlases,order)
 % reorders an atlas struct based on the order supplied
-atlases.names=atlases.names(order);
-atlases.types=atlases.types(order);
-atlases.tissuetypes=atlases.tissuetypes(order);
+try atlases.names=atlases.names(order); end
+try atlases.types=atlases.types(order); end
+try atlases.tissuetypes=atlases.tissuetypes(order); end
 atlases.colors=atlases.colors(order);
-atlases.fv=atlases.fv(order,:);
-atlases.cdat=atlases.cdat(order,:);
-atlases.XYZ=atlases.XYZ(order,:);
-atlases.pixdim=atlases.pixdim(order,:);
-atlases.colorc=atlases.colorc(order,:);
-atlases.normals=atlases.normals(order,:);
+try atlases.fv=atlases.fv(order,:); end
+try atlases.roi=atlases.roi(order,:); end
+
+try atlases.cdat=atlases.cdat(order,:); end
+try atlases.XYZ=atlases.XYZ(order,:); end
+try atlases.pixdim=atlases.pixdim(order,:); end
+try atlases.colorc=atlases.colorc(order,:); end
+try atlases.normals=atlases.normals(order,:); end
 
 try
 for p=1:length(atlases.presets)

--- a/helpers/gui/ea_getsubindex.m
+++ b/helpers/gui/ea_getsubindex.m
@@ -12,7 +12,7 @@ if uselabelname ~= 0
 end
 
 for p=1:length(surfs)
-    if strcmp(surfs(p).Tag,[sel,sidec])
+    if strcmp(surfs{p}.Tag,[sel,sidec])
         ixs=p;
         break
     end

--- a/lead_group.m
+++ b/lead_group.m
@@ -1714,5 +1714,7 @@ function exportstats_Callback(hObject, eventdata, handles)
 % handles    structure with handles and user data (see GUIDATA)
 M = getappdata(gcf,'M');
 [file, path] = uiputfile('*.mat','Export DBS Stats as...', [M.root, 'ea_stats_export.mat']);
-ea_lg_exportstats(M, [path, file]);
-fprintf('\nDBS Stats exported to:\n%s\n\n', [path, file]);
+if file % make sure user didnt press cancel
+    ea_lg_exportstats(M, [path, file]);
+    fprintf('\nDBS Stats exported to:\n%s\n\n', [path, file]);
+end


### PR DESCRIPTION
This patch will show atlases using the ea_roi class as objects.
It has several advantages over the classical approach where ea_roi objects could be more easily customized and are used throughout lead-dbs to show volumetric data. Right clicking on color tooltip buttons in the toolbar will open a control window with which atlases can be customized.
Stats out of lead group and lead-dbs were tested and still work.
Unless I have forgotten something, this should be okay to merge.