### PR TITLE
Minor electrode naming fix

### DIFF
--- a/templates/electrode_models/ea_resolve_elspec.m
+++ b/templates/electrode_models/ea_resolve_elspec.m
@@ -58,7 +58,7 @@ switch elmodel
         elspec.contact_spacing=0.5;
         elspec.numel=4;
         elspec.tipiscontact=0;
-        elspec.contactnames={'K0 (R)','K1 (R)','K2 (R)','K3 (R)','K8 (L)','K9 (L)','K10 (L)','R_K11 (L)'};
+        elspec.contactnames={'K0 (R)','K1 (R)','K2 (R)','K3 (R)','K8 (L)','K9 (L)','K10 (L)','K11 (L)'};
         elspec.isdirected=0;
         elspec.etagenames{1}=elspec.contactnames(1:length(elspec.contactnames)/2);
         elspec.etagenames{2}=elspec.contactnames((length(elspec.contactnames)/2)+1:end);


### PR DESCRIPTION
ea_resolve_elspec.m, model 3389 had "R_K11 (L)" instead of just "K11 (L)"
    root/templates/electrode_models/ea_resolve_elspec.m