### PR TITLE
Bugfix for meshresample in the iso2mesh toolbox

### DIFF
--- a/ext_libs/iso2mesh/meshresample.m
+++ b/ext_libs/iso2mesh/meshresample.m
@@ -19,6 +19,7 @@ function [node,elem]=meshresample(v,f,keepratio)
 %
 % -- this function is part of iso2mesh toolbox (http://iso2mesh.sf.net)
 %
+% proposed bugfix (for leaddbs use case) by Enrico Opri, 2020.
 
 [node,elem]=domeshsimplify(v,f,keepratio);
 
@@ -37,11 +38,48 @@ saveoff(node,elem,mwpath('post_remesh.off'));
 end
 
 % function to perform the actual resampling
-function [node,elem]=domeshsimplify(v,f,keepratio)
-  exesuff=getexeext;
+function [node,elem]=domeshsimplify(node,elem,keepratio)
 
-  saveoff(v,f,mwpath('pre_remesh.off'));
-  deletemeshfile(mwpath('post_remesh.off'));
-  system([' "' mcpath('cgalsimp2') exesuff '" "' mwpath('pre_remesh.off') '" ' num2str(keepratio) ' "' mwpath('post_remesh.off') '"']);
-  [node,elem]=readoff(mwpath('post_remesh.off'));
+    if true
+        %This is just forcing the checkrepair for manifold condition from iso2mesh toolbox (using CGAL tool <cgalsimp2>)
+        
+        %Considering that its input is not always manifold in leaddbs (e.g. VATmodel/ea_mesh_electrode)
+        %we may have to force the checkrepair first. For now I am assuming 
+        %<manifold> is not a guaranteed condition before resample (forcing check&repair+meshfix)
+        [node,elem]=meshcheckrepair(node,elem);
+        [node,elem]=meshcheckrepair(node,elem,'meshfix');  
+        
+        exesuff=getexeext;
+        saveoff(node,elem,mwpath('pre_remesh.off'));
+        deletemeshfile(mwpath('post_remesh.off'));
+        cmd_str=[' "' mcpath('cgalsimp2') exesuff '" "' mwpath('pre_remesh.off') '" ' num2str(keepratio) ' "' mwpath('post_remesh.off') '"'];
+        fprintf('command: %s\n',cmd_str);%useful for DEBUG
+        system(cmd_str);
+        [node,elem]=readoff(mwpath('post_remesh.off'));
+    else
+        %drop in replacement for mesh simplification. Using the mesh
+        %simplification available in matlab.
+        %The original cgalsimp2 can be slower, and requires the input to be <manifold> 
+
+        %Considering that its input is not always manifold in leaddbs (e.g. VATmodel/ea_mesh_electrode)
+        %we may have to force the checkrepair first. For now I am assuming 
+        %<manifold> is not a guaranteed condition before resample (forcing check&repair)
+        [node,elem]=meshcheckrepair(node,elem);
+
+        %node is vertex, elem is face
+        nfv = reducepatch(node,elem,keepratio);
+        elem=nfv.faces;
+        node=nfv.vertices;
+        
+        % Check/repair to make sure it is manifold (as matlab sometimes
+        % reduces it to a non-manifold mesh. Used the matlab reducepatch
+        % to reduce the number of dependancies.
+        % Consider switching to Surf Ice https://github.com/neurolabusc/surf-ice/
+        % ref: http://www.alecjacobson.com/weblog/?p=4444
+        % other wrappers at (but non-trivial to compile): https://github.com/alecjacobson/gptoolbox/
+        [node,elem]=meshcheckrepair(node,elem);%runs options: dupnode, duplicated, isolated, deep
+        %deep should have already been executed by the previous line. In case the toolbox changes, I enforce the removal non-manifold vertices
+        [node,elem]=meshcheckrepair(node,elem,'deep');
+        [node,elem]=meshcheckrepair(node,elem,'meshfix');        
+    end
 end


### PR DESCRIPTION
The issue is caused by part of the code that uses matlab's reducepath before running meshresample.
Some has already been taken care of (ea_mesh_electrode.m) by removing reducepatch.
Matlab's reducepath can cause an output that is non-manifold, even if the input is manifold.
This causes issues in the CGAL tool "cgalsimp2" used for the resampling in the iso2mex.
The meshresample internal check in not sufficient to cover a case of no manifoldness. This is because non-manifold meshes can cause cgalsim2 to hang forever, never reaching the condition that would trigger the meshrepair (meshcheckrepair.m).

The bugfix is to ensure that the input is manifold, by forcing the meshcheckrepair within meshresample, which repairs the mesh ensuring the manifold condition.
I've also left alternative code (currently not used) to execute meshresample based only on reducepath, but repairing the output to ensuring the manifold condition.