### PR TITLE
Enabling support for unilateral DBS cases (e.g. only left side DBS)

### DIFF
--- a/connectomics/ea_cvshowfiberconnectivities.m
+++ b/connectomics/ea_cvshowfiberconnectivities.m
@@ -333,7 +333,8 @@ if options.writeoutpm
 end
 
 % plot fibers that do connect to seed:
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     if ~isempty(connectingfibs{side})
         % Remove single point
         single = cellfun(@(x) all(size(x)==[1,3]),connectingfibs{side});

--- a/connectomics/ea_cvshowvatfmri.m
+++ b/connectomics/ea_cvshowvatfmri.m
@@ -57,7 +57,8 @@ else
     end
 end
 
-for side = 1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     seedcon=cm(side,:);
     seedcon=seedcon(3:end);
     thresh=get(handles.vatthresh,'String');

--- a/connectomics/ea_extract_timecourses_vat.m
+++ b/connectomics/ea_extract_timecourses_vat.m
@@ -12,8 +12,9 @@ stim=stims{get(handles.vatseed,'Value')};
 voxelmask.locsvx=[];
 voxelmask.vals=[];
 voxelmask.locsmm=[];
-for side=1:length(options.sides)
-    Vvat=spm_vol([directory,'stimulations',filesep,ea_nt(options),stim,filesep,'vat_',usevat{options.sides(side)},'.nii,1']);
+for iside=1:length(options.sides)
+    side=options.sides(iside);
+    Vvat=spm_vol([directory,'stimulations',filesep,ea_nt(options),stim,filesep,'vat_',usevat{side},'.nii,1']);
     Xvat=spm_read_vols(Vvat);
     nonzeros=find(Xvat(:));
     vv=Xvat(nonzeros);
@@ -25,6 +26,8 @@ for side=1:length(options.sides)
     locsmm=locsmm(:,1:3);
     voxelmask.locsmm=[voxelmask.locsmm;locsmm];
     voxelmask.locsvx=[voxelmask.locsvx;locsvx];
+    %Mod: check if it is ok to leave as side indexes 
+    %(which not necessarily start from 1), or with the iside indexes
     voxelmask.vals=[voxelmask.vals;vals*side];
 end
 

--- a/dev/genprobmaps/ea_normsubcorticalsegm.m
+++ b/dev/genprobmaps/ea_normsubcorticalsegm.m
@@ -15,8 +15,8 @@ mkdir([mniatldir,'rh']);
 whichnormmethod=ea_whichnormmethod(directory);
 
 srcs={'Pallidum','Ruber','STN'};
-for side=1:length(options.sides)
-    switch options.sides(side)
+for iside=1:length(options.sides)
+    switch options.sides(iside)
         case 1
             sidec='rh';
         case 2

--- a/ea_calc_vatstats.m
+++ b/ea_calc_vatstats.m
@@ -67,7 +67,12 @@ for but=1:length(togglenames)
     eval([togglenames{but},'=getappdata(resultfig,''',togglenames{but},''');']);
     expand=1;
     if isempty(eval(togglenames{but}))
-        eval([togglenames{but},'=repmat(1,expand,length(options.sides));']);
+        %eval([togglenames{but},'=repmat(1,expand,length(options.sides));']);
+        %changed to max, as to include for sure the array as large as the maximum side used, 
+        %as this code was intended for the bilateral cases
+        %maybe will have to change it to minimum have two elements, to always include at least R and L sides
+        %For example, before if the side was only Left, the multiplier would have been only 1
+        eval([togglenames{but},'=repmat(1,expand,max(options.sides));']);
     end
 
     setappdata(resultfig,togglenames{but},eval(togglenames{but}));
@@ -87,9 +92,10 @@ end
 
 [ea_stats,thisstim]=ea_assignstimcnt(ea_stats,S);
 
-if isstruct(VAT{1}.VAT) || isstruct(VAT{2}.VAT) % e.g. simbio model used
+if (isfield(VAT{1},'VAT') && isstruct(VAT{1}.VAT)) || ((length(VAT)>1) && isfield(VAT{2},'VAT') && isstruct(VAT{2}.VAT)) % e.g. simbio model used
     vat=1;
-    for side=1:length(options.sides)
+    for iside=1:length(options.sides)
+        side=options.sides(iside);
         try
             nVAT{side}.VAT{vat}=VAT{side}.VAT.vertices;
             K(side).K{vat}=VAT{side}.VAT.faces;
@@ -101,7 +107,8 @@ if isstruct(VAT{1}.VAT) || isstruct(VAT{2}.VAT) % e.g. simbio model used
     VAT=nVAT;
 end
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     switch side
         case 1
             sidec='right';
@@ -230,7 +237,8 @@ for side=1:length(options.sides)
 end
 
 % correct togglestates
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     if ~vaton(side)
         try
             objvisible([],[],PL.vatsurfs(side,:),resultfig,'vaton',[],side,0)

--- a/ea_elvis.m
+++ b/ea_elvis.m
@@ -193,7 +193,8 @@ if ~strcmp(options.patientname,'No Patient Selected') % if not initialize empty 
                vizstruct=struct('faces',[],'vertices',[],'colors',[]);
 
                cnt=1;
-                for side=1:length(options.sides)
+                for iside=1:length(options.sides)
+                    side=options.sides(iside);
                     extract=1:length(el_render(side).elpatch);
                     for ex=extract
                         tp=el_render(side).elpatch(ex);
@@ -377,7 +378,8 @@ if options.d3.writeatlases && ~strcmp(options.atlasset, 'Use none')
         end
         % export vizstruct
         try
-            for side=1:length(options.sides)
+            for iside=1:length(options.sides)
+                side=options.sides(iside);
                 for atl=1:length(atlases.fv)
                     if isfield(atlases.fv{atl,side},'faces')
                         vizstruct(cnt+1).faces=atlases.fv{atl,side}.faces;
@@ -659,10 +661,11 @@ if(getappdata(gcf,'altpressed'))
     eltog=getappdata(hobj.Parent.Parent,'eltog');
     set(eltog,'State',onoff);
     for el=1:length(atls)
-        for side=1:length(options.sides)
-           try
+        for iside=1:length(options.sides)
+            side=options.sides(iside);
+            try
                set(atls(el).el_render{side}, 'Visible', onoff);
-           end
+            end
         end
     end
 else

--- a/ea_exportisovolume.m
+++ b/ea_exportisovolume.m
@@ -16,7 +16,8 @@ else
     
     ea_error('Isomatrix has wrong size. Please specify a correct matrix.')
 end
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
 
     cnt=1;
     for sub=1:length(elstruct)

--- a/ea_genvat_dembek.m
+++ b/ea_genvat_dembek.m
@@ -27,7 +27,7 @@ ethresh_pw = options.prefs.machine.vatsettings.dembek_ethreshpw;
 pw = options.prefs.machine.vatsettings.dembek_pw;
 
 
-switch options.sides(side)
+switch side
     case 1
         sidec='R';
         cnts={'k0','k1','k2','k3','k4','k5','k6','k7'};
@@ -117,10 +117,10 @@ mkdir([options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(opt
 %S(side).volume=sum(volume);
 
 
-if options.sides(side) == 1
+if side == 1
     Vvat.fname=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'vat_right.nii'];
     stimfile=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'stimparameters_right.mat'];
-elseif options.sides(side) == 2
+elseif side == 2
     Vvat.fname=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'vat_left.nii'];
     stimfile=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'stimparameters_left.mat'];
 end

--- a/ea_genvat_kuncel.m
+++ b/ea_genvat_kuncel.m
@@ -24,7 +24,7 @@ end
 
 
 
-switch options.sides(side)
+switch side
     case 1
         sidec='R';
         cnts={'k0','k1','k2','k3','k4','k5','k6','k7'};
@@ -110,10 +110,10 @@ mkdir([options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(opt
 %S(side).volume=sum(volume);
 
 
-if options.sides(side) == 1
+if side == 1
     Vvat.fname=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'vat_right.nii'];
     stimfile=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'stimparameters_right.mat'];
-elseif options.sides(side) == 2
+elseif side == 2
     Vvat.fname=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'vat_left.nii'];
     stimfile=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'stimparameters_left.mat'];
 end

--- a/ea_genvat_maedler.m
+++ b/ea_genvat_maedler.m
@@ -24,7 +24,7 @@ end
 
 
 
-switch options.sides(side)
+switch side
     case 1
         sidec='R';
         cnts={'k0','k1','k2','k3','k4','k5','k6','k7'};
@@ -113,10 +113,10 @@ mkdir([options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(opt
 %S(side).volume=sum(volume);
 
 
-if options.sides(side) == 1
+if side == 1
     Vvat.fname=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'vat_right.nii'];
     stimfile=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'stimparameters_right.mat'];
-elseif options.sides(side) == 2
+elseif side == 2
     Vvat.fname=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'vat_left.nii'];
     stimfile=[options.root,options.patientname,filesep,'stimulations',filesep,ea_nt(options),stimname,filesep,'stimparameters_left.mat'];
 end

--- a/ea_load_reconstruction.m
+++ b/ea_load_reconstruction.m
@@ -86,6 +86,7 @@ if exist('reco','var')
         elmodel=reco.props(1).elmodel;
     end
 
+    %if elmodel is empty, search for the first available side that has a model
     if isempty(elmodel)
         for side=1:length(reco.props)
             elmodel=reco.props(side).elmodel;
@@ -100,7 +101,9 @@ else % legacy format
         options=ea_getptopts(directory,options);
     end
     if ~exist('markers','var') % backward compatibility to old recon format
-        for side=1:options.sides
+        for iside=1:length(options.sides)
+            side=options.sides(iside);
+
             markers(side).head=coords_mm{side}(1,:);
             markers(side).tail=coords_mm{side}(4,:);
             [xunitv, yunitv] = ea_calcxy(markers(side).head, markers(side).tail);

--- a/ea_mapelmodel2reco.m
+++ b/ea_mapelmodel2reco.m
@@ -17,13 +17,15 @@ else
 end
 
 if redomarkers
-    for iside=options.sides
-        elstruct.markers(iside).head=elstruct.coords_mm{iside}(1,:);
-        elstruct.markers(iside).tail=elstruct.coords_mm{iside}(4,:);
+    for iside=1:length(options.sides)
+        side=options.sides(iside);
+        
+        elstruct.markers(side).head=elstruct.coords_mm{side}(1,:);
+        elstruct.markers(side).tail=elstruct.coords_mm{side}(4,:);
 
-        [xunitv, yunitv] = ea_calcxy(elstruct.markers(iside).head, elstruct.markers(iside).tail);
-        elstruct.markers(iside).x = elstruct.coords_mm{iside}(1,:) + xunitv*(options.elspec.lead_diameter/2);
-        elstruct.markers(iside).y = elstruct.coords_mm{iside}(1,:) + yunitv*(options.elspec.lead_diameter/2);
+        [xunitv, yunitv] = ea_calcxy(elstruct.markers(side).head, elstruct.markers(side).tail);
+        elstruct.markers(side).x = elstruct.coords_mm{side}(1,:) + xunitv*(options.elspec.lead_diameter/2);
+        elstruct.markers(side).y = elstruct.coords_mm{side}(1,:) + yunitv*(options.elspec.lead_diameter/2);
     end
 end
 

--- a/ea_prefs.m
+++ b/ea_prefs.m
@@ -36,7 +36,7 @@ try
         % file name starting with '.' is not a valid function/script name, so
         % copy it to a temp file and then run it.
         tempPrefs = ['ea_prefs_', strrep(ea_generate_uuid, '-', '_')];
-        copyfile([home, '.ea_prefs.m'], [ea_getearoot, tempPrefs, '.m']);
+        copyfile([home, '.ea_prefs.m'], [ea_getearoot, tempPrefs, '.m'],'f');
         uprefs = feval(tempPrefs, patientname);
         delete([ea_getearoot, tempPrefs, '.m']);
         umachine = load([home, '.ea_prefs.mat']);

--- a/ea_reconstruction2acpc.m
+++ b/ea_reconstruction2acpc.m
@@ -3,7 +3,8 @@ function ea_reconstruction2acpc(options)
 directory=[options.root,options.patientname,filesep];
 load([directory,filesep,'ea_reconstruction.mat']);
 
-for side=options.sides
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     for c=1:size(reco.native.coords_mm{side}(:,1),1)
         cfg.xmm=reco.native.coords_mm{side}(c,1);
         cfg.ymm=reco.native.coords_mm{side}(c,2);

--- a/ea_refinecoords.m
+++ b/ea_refinecoords.m
@@ -50,7 +50,7 @@ function [coords_mm,trajectory,markers] = ea_refinecoords(options)
     end
 
 
-    for side = options.sides(1):options.sides(end)
+    for side = options.sides
         options.elside = side;
         meantrajectory = genhd_inside(trajectory{side});
         imat = ea_resample_planes(V, meantrajectory', sample_width, doxx, 0.2);

--- a/ea_reformat_isomatrix.m
+++ b/ea_reformat_isomatrix.m
@@ -9,7 +9,8 @@ function isom=ea_reformat_isomatrix(isom,M,options)
 
 if ~iscell(isom) % check if isomatrix is a cell ({[right_matrix]},{[left_matrix]}), if not convert to one.
     if min(size(isom))==1 && length(size(isom))==2 % single vector (1 value for each patient)
-        for side=1:length(options.sides)
+        for iside=1:length(options.sides)
+            side=options.sides(iside);
             try
                 stimmat{side}=cat(1,M.stimparams(:,1).U);
             catch
@@ -18,7 +19,8 @@ if ~iscell(isom) % check if isomatrix is a cell ({[right_matrix]},{[left_matrix]
             stimmat{side}=bsxfun(@times,stimmat{side}>0,isom);
         end
     elseif min(size(isom))==2 && length(size(isom))==2 % 2xn matrix (1 value for each hemisphere)
-        for side=1:length(options.sides)
+        for iside=1:length(options.sides)
+            side=options.sides(iside);
             try
                 stimmat{side}=cat(1,M.stimparams(:,1).U);
             catch
@@ -39,7 +41,8 @@ if ~iscell(isom) % check if isomatrix is a cell ({[right_matrix]},{[left_matrix]
 end
 
 if options.normregressor>1 % apply normalization to regressor data
-    for side=1:length(options.sides)
+    for iside=1:length(options.sides)
+        side=options.sides(iside);
         if options.normregressor==2 % apply z-score
             stimmat{side}=reshape(nanzscore(stimmat{side}(:)),size(stimmat{side},1),size(stimmat{side},2));
         elseif options.normregressor==3 % apply normal method from van albada 2008

--- a/ea_runpacer.m
+++ b/ea_runpacer.m
@@ -22,14 +22,18 @@ if(length(elecmodels) ~= length(options.sides))
        'due to untypical CT data. Please provide a brain mask to PaCER in this case using the mask parameter.']);
 end
 
-for side=options.sides
+for iside=1:length(options.sides)
+    side=options.sides(iside);
+    
+    %{
     if length(elecmodels) == 1 % fix in case only left electrode
         side2 = 1;
     else
         side2 = side;
     end
+    %}
 
-    coords_mm{side}=[tmat*[elecmodels{side2}.getContactPositions3D,ones(size(elecmodels{side2}.getContactPositions3D,1),1)]']';%#ok<NBRAK,AGROW>
+    coords_mm{side}=[tmat*[elecmodels{iside}.getContactPositions3D,ones(size(elecmodels{iside}.getContactPositions3D,1),1)]']';%#ok<NBRAK,AGROW>
     coords_mm{side}=coords_mm{side}(:,1:3);%#ok<AGROW>
     for dim=1:3
         trajectory{side}(:,dim)=linspace(coords_mm{side}(1,dim),coords_mm{side}(1,dim)+10*(coords_mm{side}(1,dim)-coords_mm{side}(end,dim)),20);%#ok<AGROW>

--- a/ea_runtraccore.m
+++ b/ea_runtraccore.m
@@ -69,7 +69,7 @@ for side=options.sides
 end
 
 % transform trajectory to mm space:
-for side=1:length(options.sides)
+for side=options.sides
     try
         if ~isempty(trajectory{side})
             trajectory{side}=ea_map_coords(trajectory{side}', [directory,'lpost.nii'])';

--- a/ea_sample_slice.m
+++ b/ea_sample_slice.m
@@ -22,11 +22,11 @@ if strcmp(voxmm,'mm')
     %
 end
 if iscell(coords)
-allc=[];
-for side=1:length(coords)
-    allc=[allc;coords{side}];
-end
-coords=allc;
+    allc=[];
+    for side=1:length(coords)
+        allc=[allc;coords{side}];
+    end
+    coords=allc;
 end
 
 if length(coords)==1 % scalar input, only a height is defined. convert to mm space.
@@ -34,6 +34,14 @@ if length(coords)==1 % scalar input, only a height is defined. convert to mm spa
 else
     getfullframe=0;
 end
+
+if any(isnan(coords(el,:)))
+    %set all to nan and return
+    %this is because there was no electrode here (nan coordinate)
+    [slice,boundbox,boundboxmm,sampleheight]=deal(nan);
+    return
+end
+
 switch tracor
     case 'tra'
         if getfullframe

--- a/ea_showcorticalstrip.m
+++ b/ea_showcorticalstrip.m
@@ -23,7 +23,9 @@ end
 
 jetlist=jet;
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
+
     trajvector=mean(diff(trajectory{side}));
 
     trajvector=trajvector/norm(trajvector);
@@ -56,13 +58,15 @@ for side=1:length(options.sides)
         end
 
         if redomarkers
-            for iside=options.sides
-                elstruct.markers(iside).head=elstruct.coords_mm{iside}(1,:);
-                elstruct.markers(iside).tail=elstruct.coords_mm{iside}(4,:);
+            for iside2=1:length(options.sides)
+                side2=options.sides(iside2);
 
-                [xunitv, yunitv] = ea_calcxy(elstruct.markers(iside).head, elstruct.markers(iside).tail);
-                elstruct.markers(iside).x = elstruct.coords_mm{iside}(1,:) + xunitv*(options.elspec.lead_diameter/2);
-                elstruct.markers(iside).y = elstruct.coords_mm{iside}(1,:) + yunitv*(options.elspec.lead_diameter/2);
+                elstruct.markers(side2).head=elstruct.coords_mm{side2}(1,:);
+                elstruct.markers(side2).tail=elstruct.coords_mm{side2}(4,:);
+
+                [xunitv, yunitv] = ea_calcxy(elstruct.markers(side2).head, elstruct.markers(side2).tail);
+                elstruct.markers(side2).x = elstruct.coords_mm{side2}(1,:) + xunitv*(options.elspec.lead_diameter/2);
+                elstruct.markers(side2).y = elstruct.coords_mm{side2}(1,:) + yunitv*(options.elspec.lead_diameter/2);
             end
         end
 

--- a/ea_showisovolume.m
+++ b/ea_showisovolume.m
@@ -26,22 +26,26 @@ else
     ea_error('Isomatrix has wrong size. Please specify a correct matrix.')
 end
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
+    
     cnt=1;
     for sub=1:length(elstruct)
         for cont=1:size(options.d3.isomatrix{1},2)
             if ~isnan(options.d3.isomatrix{side}(sub,cont))
-                if ~shifthalfup
-                    X{side}(cnt)=elstruct(sub).coords_mm{side}(cont,1);
-                    Y{side}(cnt)=elstruct(sub).coords_mm{side}(cont,2);
-                    Z{side}(cnt)=elstruct(sub).coords_mm{side}(cont,3);
-                else % using pairs of electrode contacts (i.e. 3 pairs if there are 4 contacts)
-                    X{side}(cnt)=mean([elstruct(sub).coords_mm{side}(cont,1),elstruct(sub).coords_mm{side}(cont+1,1)]);
-                    Y{side}(cnt)=mean([elstruct(sub).coords_mm{side}(cont,2),elstruct(sub).coords_mm{side}(cont+1,2)]);
-                    Z{side}(cnt)=mean([elstruct(sub).coords_mm{side}(cont,3),elstruct(sub).coords_mm{side}(cont+1,3)]);
+                if ~isempty(elstruct(sub).coords_mm{side}) %if there are coordinates, parse them, otherwise skip to next
+                    if ~shifthalfup
+                        X{side}(cnt)=elstruct(sub).coords_mm{side}(cont,1);
+                        Y{side}(cnt)=elstruct(sub).coords_mm{side}(cont,2);
+                        Z{side}(cnt)=elstruct(sub).coords_mm{side}(cont,3);
+                    else % using pairs of electrode contacts (i.e. 3 pairs if there are 4 contacts)
+                        X{side}(cnt)=mean([elstruct(sub).coords_mm{side}(cont,1),elstruct(sub).coords_mm{side}(cont+1,1)]);
+                        Y{side}(cnt)=mean([elstruct(sub).coords_mm{side}(cont,2),elstruct(sub).coords_mm{side}(cont+1,2)]);
+                        Z{side}(cnt)=mean([elstruct(sub).coords_mm{side}(cont,3),elstruct(sub).coords_mm{side}(cont+1,3)]);
+                    end
+                    V{side}(cnt)=options.d3.isomatrix{side}(sub,cont);
+                    cnt=cnt+1;
                 end
-                V{side}(cnt)=options.d3.isomatrix{side}(sub,cont);
-                cnt=cnt+1;
             end
         end
     end

--- a/ea_stimparams.m
+++ b/ea_stimparams.m
@@ -204,8 +204,9 @@ if ~strcmp(options.leadprod, 'group')
             stimparams(1,1).volume = vatvolume;
         elseif  exist([directory,'stimulations',filesep,ea_nt(options),label,filesep,'vat_left.mat'],'file') == 2
             load([directory,'stimulations',filesep,ea_nt(options),label,filesep,'vat_left.mat']);
-            stimparams(1,1).VAT.VAT = vatfv;
-            stimparams(1,1).volume = vatvolume;
+            %For consistency, left is always on 2nd element of stimparams 
+            stimparams(1,2).VAT.VAT = vatfv;
+            stimparams(1,2).volume = vatvolume;
         else
             if exist([directory,'stimulations',filesep,ea_nt(options),label,filesep,'vat_right.nii'],'file') == 2 && exist([directory,'stimulations',filesep,ea_nt(options),label,filesep,'vat_left.nii'],'file') == 2
                 nii = ea_load_nii([directory,'stimulations',filesep,ea_nt(options),label,filesep,'vat_right.nii']);
@@ -225,7 +226,8 @@ if ~strcmp(options.leadprod, 'group')
                 nii = ea_load_nii([directory,'stimulations',ea_nt(options),filesep,label,filesep,'vat_left.nii']);
                 vatfv = ea_niiVAT2fvVAT(nii);
     %             vatfv = ea_smoothpatch(vatfv,1,35);
-                stimparams(1,1).VAT.VAT = vatfv;
+                %For consistency, left is always on 2nd element of stimparams 
+                stimparams(1,2).VAT.VAT = vatfv;
             else
                 visualizeVAT = 0;
             end
@@ -1052,7 +1054,9 @@ ea_genvat=eval(['@',genvatfunctions{get(handles.modelselect,'Value')}]);
 stimname=S.label;
 
 for el=1:length(elstruct)
-    for side=1:length(elstruct.coords_mm)
+    for iside=1:length(options.sides)%length(elstruct.coords_mm)
+        side=options.sides(iside);
+
         if isfield(elstruct,'group') % group analysis, more than one electrode set
             % this should not happen, in this case the stim button is
             % hidden.
@@ -2155,6 +2159,9 @@ axis equal;
 %% check consistency with chosen VAT model.
 %% check consistency with chosen electrode model.
 if ~isfield(options,'elspec')
+    if isempty(elstruct(actpt).elmodel)
+        error('Model is empty. Was the electrode segmentation fully executed in single patient mode?')
+    end
     toptions=ea_resolve_elspec(elstruct(actpt));
     try
         options.elspec=toptions.elspec;
@@ -2235,6 +2242,20 @@ else % Ampere
     ea_show_percent(handles,options,2,'on'); % left hemisphere
 end
 
+% enable/disable panel based on sides that are present
+is_side_present=arrayfun(@(xside) ~ea_arenopoints4side(elstruct(actpt).trajectory, xside), [1,2]);%First element is R, second is L
+if is_side_present(1)>0%check if R side is present
+    set(findall(handles.uipanel2, '-property', 'enable'), 'enable', 'on')
+else
+    set(findall(handles.uipanel2, '-property', 'enable'), 'enable', 'off')
+end
+if is_side_present(2)>0%check if L side is present
+    set(findall(handles.uipanel3, '-property', 'enable'), 'enable', 'on')
+else
+    set(findall(handles.uipanel3, '-property', 'enable'), 'enable', 'off')
+end
+
+
 ea_savestimulation(S,options);
 setappdata(handles.stimfig,'S',S);
 
@@ -2283,10 +2304,12 @@ set(handles.kohmtext4,'visible',cmd);
 function ea_disable_vas(handles,options)
 
 RL={'R','L'};
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
+
     for Rva=1:4
-        set(handles.([RL{options.sides(side)},'s',num2str(Rva),'va']),'enable','off');
-        set(handles.([RL{options.sides(side)},'s',num2str(Rva),'va']),'value',1);
+        set(handles.([RL{side},'s',num2str(Rva),'va']),'enable','off');
+        set(handles.([RL{side},'s',num2str(Rva),'va']),'value',1);
     end
 end
 
@@ -2294,9 +2317,11 @@ end
 function ea_enable_vas(handles,options)
 
 RL={'R','L'};
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
+
     for Rva=1:4
-        set(handles.([RL{options.sides(side)},'s',num2str(Rva),'va']),'enable','on');
+        set(handles.([RL{side},'s',num2str(Rva),'va']),'enable','on');
     end
 end
 

--- a/ea_write.m
+++ b/ea_write.m
@@ -67,7 +67,8 @@ end
 
 %% check traject sanity
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     try
         trajectissane=ea_checktrajectsanity(trajvector{side});
         if ~trajectissane

--- a/helpers/ea_arenopoints4side.m
+++ b/helpers/ea_arenopoints4side.m
@@ -1,0 +1,17 @@
+function out=ea_arenopoints4side(coords_list, side)
+    %returns true if there are no valid points for this side (if points is empty or if it is all nan)
+    %this is helpful for determining if it is a valid side with .coords_mm, .coords_acpc, .trajectory
+    %Enrico Opri, 2020
+    
+    %this assumes hardcoded R side as 1, and L as 2
+    if length(coords_list)<side
+        %the side does not exist
+        out=true;
+    else
+        out=ea_arenopoints(coords_list{side});
+    end
+    
+    function out=ea_arenopoints(points)
+        out=isempty(points) || all(isnan(points(:)));
+    end
+end

--- a/helpers/ea_elstruct_match_and_nanfill.m
+++ b/helpers/ea_elstruct_match_and_nanfill.m
@@ -1,0 +1,65 @@
+function elstruct=ea_elstruct_match_and_nanfill(elstruct)
+    %Fill missing sides with nans, matching it to the other present side (e.g. L and R).
+    %At least one side should be present, which should be always the case.
+    %Enrico Opri, 2020
+
+    %the minimum number of sides is two. First is R, second is L
+    for el=1:length(elstruct)
+        if isfield(elstruct(el),'coords_mm')
+            if length(elstruct(el).coords_mm)==1
+                elstruct(el).coords_mm{2}=[];
+            elseif isempty(elstruct(el).coords_mm)
+                error('need to have at least 1 tract')
+            end
+            %match and fill if necessary.
+            elstruct(el).coords_mm=match_and_nanfill(elstruct(el).coords_mm);
+        end
+
+        if isfield(elstruct(el),'coords_acpc')
+            if length(elstruct(el).coords_acpc)==1
+                elstruct(el).coords_acpc{2}=[];
+            elseif isempty(elstruct(el).coords_acpc)
+                error('need to have at least 1 tract')
+            end
+            %match and fill if necessary.
+            elstruct(el).coords_acpc=match_and_nanfill(elstruct(el).coords_acpc);
+        end
+        %{
+        %for now do not apply this match to the trajectory
+        if isfield(elstruct(el),'trajectory')
+            if length(elstruct(el).trajectory)==1
+                elstruct(el).trajectory{2}=[];
+            elseif isempty(elstruct(el).trajectory)
+                error('need to have at least 1 tract')
+            end
+            %match and fill if necessary.
+            elstruct(el).trajectory=match_and_nanfill(elstruct(el).trajectory);
+        end
+        %}   
+    end
+end
+
+function coords=match_and_nanfill(coords)
+    num_points=nan;%contacts in the case of coords_mm and coords_acpc, points in the case of trajectory
+    num_axes=nan;
+    for iside=1:length(coords)
+        side=iside;%just for readability, as this is the side
+        if ~isempty(coords{side})
+            num_points=size(coords{side},1);
+            num_axes=size(coords{side},2);
+            break;
+        end
+    end
+    if isnan(num_points) || isnan(num_axes)
+        error('This should not happen, is there no electrode set yet? Remember to run the electrode/lead reconstruction first (Panel 5)');
+    end
+
+    for iside=1:length(coords)
+        %side=options.sides(iside);
+        side=iside;%just for readability, as this is the side
+        if isempty(coords{side})
+            %fill with nans, to leave a placeholder for no contact/electrode/lead
+            coords{side}=nan(num_points,num_axes);
+        end
+    end
+end

--- a/helpers/ea_elstruct_match_and_nanfill.m
+++ b/helpers/ea_elstruct_match_and_nanfill.m
@@ -15,7 +15,7 @@ function elstruct=ea_elstruct_match_and_nanfill(elstruct)
             elstruct(el).coords_mm=match_and_nanfill(elstruct(el).coords_mm);
         end
 
-        if isfield(elstruct(el),'coords_acpc')
+        if isfield(elstruct(el),'coords_acpc') && ~isnan(elstruct(el).coords_acpc)
             if length(elstruct(el).coords_acpc)==1
                 elstruct(el).coords_acpc{2}=[];
             elseif isempty(elstruct(el).coords_acpc)

--- a/helpers/ea_get_first_notempty_elmodel.m
+++ b/helpers/ea_get_first_notempty_elmodel.m
@@ -1,0 +1,22 @@
+function elmodel=ea_get_first_notempty_elmodel(reco___props)
+    % elmodel=ea_get_first_notempty_elmodel(reco.props)
+    % Copyright (C) 2020 Emory University, USA, School of Medicine
+    % Enrico Opri
+
+    elmodel=[];
+    if ~isempty(reco___props)
+        for side=1:length(reco___props)
+            elmodel=reco___props(side).elmodel;
+            if ~isempty(elmodel)
+                break
+            end
+        end
+    end
+
+    %if it is still empty, return empty and throw a warning
+    if isempty(elmodel)
+        %no model was found
+        warning('No electrode model specified.');
+        elmodel=[];
+    end
+end

--- a/helpers/gui/ea_elvisible.m
+++ b/helpers/gui/ea_elvisible.m
@@ -5,7 +5,8 @@ function ea_elvisible(hobj,ev,atls,pt,side,onoff,options)
 %     eltog=getappdata(hobj.Parent.Parent,'eltog');
 %     set(eltog,'State',onoff);
 %     for el=1:length(atls)
-%         for side=1:length(options.sides)
+%         for iside=1:length(options.sides)
+%            side=options.sides(iside);
 %            try
 %                set(atls(el).el_render{side}, 'Visible', onoff);
 %            end

--- a/helpers/gui/ea_load_pts.m
+++ b/helpers/gui/ea_load_pts.m
@@ -54,7 +54,9 @@ try
           end
        end
        try
-           [~,locb] = ismember({reco.props(1).elmodel},handles.electrode_model_popup.String);
+           %[~,locb] = ismember({reco.props(1).elmodel},handles.electrode_model_popup.String);
+           elmodel=ea_get_first_notempty_elmodel(reco.props);
+           [~,locb] = ismember({elmodel},handles.electrode_model_popup.String);
            set(handles.electrode_model_popup,'Value',locb);
            clear locb
        end

--- a/predict/ea_getXvat.m
+++ b/predict/ea_getXvat.m
@@ -13,22 +13,50 @@ end
 cnt=1;
 
 for pt=1:length(M.patient.list)
-    nii=ea_load_nii([options.root,options.patientname,filesep,'statvat_results',filesep,'s',num2str(pt),'_lh.nii']);
-    if ~exist('X','var')
-        X=nan(length(M.patient.list),numel(nii.img));
-        if bihemispheric
-            XR=X;
+    %for left side
+    fname_l=[options.root,options.patientname,filesep,'statvat_results',filesep,'s',num2str(pt),'_lh.nii'];
+    if exist(fname_l,'file')>0
+        nii=ea_load_nii(fname_l);
+        %init outputs X and XR if necessary
+        if ~exist('X','var')
+            X=nan(length(M.patient.list),numel(nii.img));
+            if bihemispheric
+                XR=X;
+            end
+        end
+        X(cnt,:)=nii.img(:);
+    end
+    
+    %for right side
+    if bihemispheric
+        fname_r=[options.root,options.patientname,filesep,'statvat_results',filesep,'s',num2str(pt),'_rh.nii'];
+        if exist(fname_r,'file')>0
+            nii=ea_load_nii(fname_r);
+            %init outputs X and XR if necessary
+            if ~exist('X','var')
+                X=nan(length(M.patient.list),numel(nii.img));
+                if bihemispheric
+                    XR=X;
+                end
+            end
+            XR(cnt,:)=nii.img(:);
+            XR(cnt,:)=logical(XR(cnt,:));
+        end
+    else
+        fname_rflip=[options.root,options.patientname,filesep,'statvat_results',filesep,'s',num2str(pt),'_rh_flipped.nii'];
+        if exist(fname_rflip,'file')>0
+            nii=ea_load_nii(fname_rflip);
+            %init outputs X and XR if necessary
+            if ~exist('X','var')
+                X=nan(length(M.patient.list),numel(nii.img));
+                if bihemispheric
+                    XR=X;
+                end
+            end
+            X(cnt,:)=X(cnt,:)+nii.img(:)';
         end
     end
-    X(cnt,:)=nii.img(:);
-    if bihemispheric
-        nii=ea_load_nii([options.root,options.patientname,filesep,'statvat_results',filesep,'s',num2str(pt),'_rh.nii']);
-        XR(cnt,:)=nii.img(:);
-        XR(cnt,:)=logical(XR(cnt,:));
-    else
-        nii=ea_load_nii([options.root,options.patientname,filesep,'statvat_results',filesep,'s',num2str(pt),'_rh_flipped.nii']);
-        X(cnt,:)=X(cnt,:)+nii.img(:)';
-    end
+    
     X(cnt,:)=logical(X(cnt,:));    
     cnt=cnt+1;
 end

--- a/templates/electrode_models/ea_elspec_adtech_bf08r_sp05x.m
+++ b/templates/electrode_models/ea_elspec_adtech_bf08r_sp05x.m
@@ -37,7 +37,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=10*rescaleratio; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     % nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_adtech_rd10r_sp03x.m
+++ b/templates/electrode_models/ea_elspec_adtech_rd10r_sp03x.m
@@ -37,7 +37,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=10*rescaleratio; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     % nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_adtech_sd10r_sp05x_choi.m
+++ b/templates/electrode_models/ea_elspec_adtech_sd10r_sp05x_choi.m
@@ -37,7 +37,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=10*rescaleratio; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     % nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_boston_vercise.m
+++ b/templates/electrode_models/ea_elspec_boston_vercise.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_dixi_d08_05am.m
+++ b/templates/electrode_models/ea_elspec_dixi_d08_05am.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_dixi_d08_08am.m
+++ b/templates/electrode_models/ea_elspec_dixi_d08_08am.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_dixi_d08_10am.m
+++ b/templates/electrode_models/ea_elspec_dixi_d08_10am.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_dixi_d08_12am.m
+++ b/templates/electrode_models/ea_elspec_dixi_d08_12am.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_dixi_d08_15am.m
+++ b/templates/electrode_models/ea_elspec_dixi_d08_15am.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_dixi_d08_18am.m
+++ b/templates/electrode_models/ea_elspec_dixi_d08_18am.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_epc_05c.m
+++ b/templates/electrode_models/ea_elspec_epc_05c.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_epc_15c.m
+++ b/templates/electrode_models/ea_elspec_epc_15c.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_medtronic_3387.m
+++ b/templates/electrode_models/ea_elspec_medtronic_3387.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_medtronic_3389.m
+++ b/templates/electrode_models/ea_elspec_medtronic_3389.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_medtronic_3391.m
+++ b/templates/electrode_models/ea_elspec_medtronic_3391.m
@@ -28,10 +28,10 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
-
- coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
+    coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+2*(elspec.contact_spacing+elspec.contact_length);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+3*(elspec.contact_spacing+elspec.contact_length)];

--- a/templates/electrode_models/ea_elspec_neuropace_dl_344_10.m
+++ b/templates/electrode_models/ea_elspec_neuropace_dl_344_10.m
@@ -37,7 +37,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=10*rescaleratio; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_neuropace_dl_344_35.m
+++ b/templates/electrode_models/ea_elspec_neuropace_dl_344_35.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_pins_l301.m
+++ b/templates/electrode_models/ea_elspec_pins_l301.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_pins_l302.m
+++ b/templates/electrode_models/ea_elspec_pins_l302.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_pins_l303.m
+++ b/templates/electrode_models/ea_elspec_pins_l303.m
@@ -28,10 +28,10 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
-
- coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
+    coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+2*(elspec.contact_spacing+elspec.contact_length);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+3*(elspec.contact_spacing+elspec.contact_length)];

--- a/templates/electrode_models/ea_elspec_sde_08_s10.m
+++ b/templates/electrode_models/ea_elspec_sde_08_s10.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_sde_08_s10_legacy.m
+++ b/templates/electrode_models/ea_elspec_sde_08_s10_legacy.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_sde_08_s12.m
+++ b/templates/electrode_models/ea_elspec_sde_08_s12.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_sde_08_s12_legacy.m
+++ b/templates/electrode_models/ea_elspec_sde_08_s12_legacy.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_sde_08_s16.m
+++ b/templates/electrode_models/ea_elspec_sde_08_s16.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_sde_08_s16_legacy.m
+++ b/templates/electrode_models/ea_elspec_sde_08_s16_legacy.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_sde_08_s8.m
+++ b/templates/electrode_models/ea_elspec_sde_08_s8.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,(elspec.contact_length/2);...
         0,0,(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_sde_08_s8_legacy.m
+++ b/templates/electrode_models/ea_elspec_sde_08_s8_legacy.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length+(elspec.contact_length/2);...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*(elspec.contact_spacing+elspec.contact_length);...

--- a/templates/electrode_models/ea_elspec_stjude_activetip_2mm.m
+++ b/templates/electrode_models/ea_elspec_stjude_activetip_2mm.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length/2;...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*elspec.contact_spacing+0*elspec.contact_length;...

--- a/templates/electrode_models/ea_elspec_stjude_activetip_3mm.m
+++ b/templates/electrode_models/ea_elspec_stjude_activetip_3mm.m
@@ -28,7 +28,8 @@ jetlist=othercolor('BuOr_12');
 %   jetlist=jet;
 N=200; % resolution of electrode points
 
-for side=1:length(options.sides)
+for iside=1:length(options.sides)
+    side=options.sides(iside);
     %% nullmodel:
     coords_mm{side}=[0,0,elspec.tip_length/2;...
         0,0,elspec.tip_length+(elspec.contact_length/2)+1*elspec.contact_spacing+0*elspec.contact_length;...

--- a/templates/electrode_models/ea_resolve_elspec.m
+++ b/templates/electrode_models/ea_resolve_elspec.m
@@ -32,11 +32,14 @@ else
     options=varargin{1};
 end
 
+elmodel=[];
 if ~isfield(options, 'elmodel')
     try
         load([options.root,options.patientname,filesep,'ea_reconstruction.mat']);
-        elmodel = reco.props(1).elmodel;
+        %elmodel = reco.props(1).elmodel;
+        elmodel=ea_get_first_notempty_elmodel(reco.props);
     catch
+        %no model was found
         warning('No electrode model specified. Using Medtronic 3389.');
         elmodel = 'Medtronic 3389';
     end

--- a/templates/electrode_models/ea_resolvecoords.m
+++ b/templates/electrode_models/ea_resolvecoords.m
@@ -17,7 +17,10 @@ if nargin==4
 end
 
 load([ea_getearoot,'templates',filesep,'electrode_models',filesep,options.elspec.matfname]);
-for side=1:length(markers) % leave as is
+for side=1:length(markers)%valid for unilateral support
+%for iside=1:length(options.sides)%does not cover all the use cases
+%   side=options.sides(iside);
+    
     if resize
         can_dist=ea_pdist([electrode.head_position;electrode.tail_position]);
         %emp_dist=ea_pdist([markers(side).head;markers(side).tail]);


### PR DESCRIPTION
The following files were changed to enable support for unilateral (DBS) leads (and other bugfixes as listed below):
Enrico Opri, enrico.opri@emory.edu

## Changed handling of options.sides
### (Right is always first element/side, and Left is always the second element/side, that did not change)
Issue of reference: https://github.com/netstim/leaddbs/pull/67
```
    root/ea_calc_vatstats.m
    root/ea_reconstruction2acpc.m
    root/ea_refinecoords.m
    root/ea_elvis.m
    root/ea_exportisovolume.m
    root/ea_reformat_isomatrix.m
    root/ea_load_reconstruction.m
    root/ea_mapelmodel2reco.m    
    root/ea_runtraccore.m
    root/ea_showcorticalstrip.m
    root/ea_showisovolume.m
    root/ea_stimparams.m
    root/ea_write.m
    root/ea_writeplanes.m
    root/helpers/gui/ea_elvisible.m

    root/connectomics/ea_cvshowfiberconnectivities.m
    root/connectomics/ea_cvshowvatfmri.m
    root/connectomics/ea_extract_timecourses_vat.m

    root/ea_runpacer.m -> now handles unilateral left lead
```
this is one of the keypoints for the issue: the electrode models store the coordinates 
in an hardcoded scheme of R for side==1 and L for side==2, in options.sides
```
    root/templates/electrode_models/ea_elspec_adtech_bf08r_sp05x.m
    root/templates/electrode_models/ea_elspec_adtech_rd10r_sp03x.m
    root/templates/electrode_models/ea_elspec_adtech_sd10r_sp05x_choi.m
    root/templates/electrode_models/ea_elspec_boston_vercise.m
    root/templates/electrode_models/ea_elspec_dixi_d08_05am.m
    root/templates/electrode_models/ea_elspec_dixi_d08_08am.m
    root/templates/electrode_models/ea_elspec_dixi_d08_10am.m
    root/templates/electrode_models/ea_elspec_dixi_d08_12am.m
    root/templates/electrode_models/ea_elspec_dixi_d08_15am.m
    root/templates/electrode_models/ea_elspec_dixi_d08_18am.m
    root/templates/electrode_models/ea_elspec_epc_05c.m
    root/templates/electrode_models/ea_elspec_epc_15c.m
    root/templates/electrode_models/ea_elspec_medtronic_3387.m
    root/templates/electrode_models/ea_elspec_medtronic_3389.m
    root/templates/electrode_models/ea_elspec_medtronic_3391.m
    root/templates/electrode_models/ea_elspec_neuropace_dl_344_10.m
    root/templates/electrode_models/ea_elspec_neuropace_dl_344_35.m
    root/templates/electrode_models/ea_elspec_pins_l301.m
    root/templates/electrode_models/ea_elspec_pins_l302.m
    root/templates/electrode_models/ea_elspec_pins_l303.m
    root/templates/electrode_models/ea_elspec_sde_08_s10.m
    root/templates/electrode_models/ea_elspec_sde_08_s10_legacy.m
    root/templates/electrode_models/ea_elspec_sde_08_s12.m
    root/templates/electrode_models/ea_elspec_sde_08_s12_legacy.m
    root/templates/electrode_models/ea_elspec_sde_08_s16.m
    root/templates/electrode_models/ea_elspec_sde_08_s16_legacy.m
    root/templates/electrode_models/ea_elspec_sde_08_s8.m
    root/templates/electrode_models/ea_elspec_sde_08_s8_legacy.m
    root/templates/electrode_models/ea_elspec_stjude_activetip_2mm.m
    root/templates/electrode_models/ea_elspec_stjude_activetip_3mm.m
```
Standardized the "sides" management of these scripts (genvat and others)
```
    root/ea_genvat_dembek.m  
    root/ea_genvat_kuncel.m
    root/ea_genvat_maedler.m
    dev/genprobmaps/ea_normsubcorticalsegm.m
```
and IMPORTANTLY, the <stimparams> variable, enforcing that position 1 is right, and position 2 is left.
In addition now the ea_stimparams gui disables the panel for the stimulation settings of the lead that is not present
```
    root/ea_stimparams.m
```
To manage the case where not both sides (R and L) are present in elstruct (e.g. coords_mm), I've added ea_elstruct_match_and_nanfill.m, to get an appropriate output from ea_ave_elstruct.m
together with ea_arenopoints4side.m which returns if the side is valid.
```
    root/helpers/ea_elstruct_match_and_nanfill.m  <- added
    root/helpers/ea_arenopoints4side.m  <- added
```
This assumes that a side that is empty, can be either an empty cell (e.g. in coords_mm{1} for the R side) or filled with nans (matching the size of coords_mm{2}). This allows to not break code such as nansum, nanmean and so on.

In addition, this enables correct generation of 2D slices in ea_writeplanes.m
Issue of reference: https://github.com/netstim/leaddbs/issues/178
```
    root/ea_writeplanes.m
```
Changed how export vatmapping searches always for both sides .nii files.
```
    root/ea_exportvatmapping.m
    root/predict/ea_getXvat.m
```

## Improving handling of elmodel
Added new helper elmodel=ea_get_first_notempty_elmodel(reco.props) and ea_arenopoints4side.m
```
    root/helpers/gui/ea_load_pts.m
    root/ea_load_reconstruction.m
    root/templates/electrode_models/ea_resolve_elspec.m

    root/ea_writeplanes.m   -> the coord cell array is set to fill out the empty coordinates with NaN, to ensure compatibility with ea_sample_slice.m
    root/ea_sample_slice.m   -> modification was not strictly necessary, but done to ensure compatibility
```
To manage the case where not both sides (R and L) are present in elstruct (e.g. coords_mm), I've added ea_elstruct_match_and_nanfill.m, to get an appropriate output from ea_ave_elstruct.m
This enables correct generation of 2D slices in ea_writeplanes.m
```
    root/ea_writeplanes.m
```
fixed handling of statistics warnings in the unilateral case (which lead dbs sees as missing side==1, Right side, making part of the code fail). 
```
    root/ea_showatlas.m
```