### PR TITLE
ENH: BUG: fixing unilateral support for group analysis.

### DIFF
--- a/dev/ea_plan_revision.m
+++ b/dev/ea_plan_revision.m
@@ -52,6 +52,8 @@ for rev=1:length(revs)
     options.sides=1:length(reco.mni.markers);
     [reco.mni.coords_mm,reco.mni.trajectory,reco.mni.markers]=ea_resolvecoords(reco.mni.markers,options,0);
     delete([directory,'ea_reconstruction.mat']);
-    ea_save_reconstruction(reco.mni.coords_mm, reco.mni.trajectory, reco.mni.markers, reco.props(1).elmodel, 1, options)
+
+    elmodel=ea_get_first_notempty_elmodel(reco.props);
+    ea_save_reconstruction(reco.mni.coords_mm, reco.mni.trajectory, reco.mni.markers, elmodel, 1, options)
 end
 

--- a/ea_load_reconstruction.m
+++ b/ea_load_reconstruction.m
@@ -82,8 +82,8 @@ if exist('reco','var')
         manually_corrected=reco.props(options.elside).manually_corrected;
         elmodel=reco.props(options.elside).elmodel;
     catch % legacy
-        manually_corrected=reco.props(1).manually_corrected;
-        elmodel=reco.props(1).elmodel;
+        [elmodel,first_notempty_side]=ea_get_first_notempty_elmodel(reco.props);
+        manually_corrected=reco.props(first_notempty_side).manually_corrected;
     end
 
     %if elmodel is empty, search for the first available side that has a model

--- a/ea_showelectrode.m
+++ b/ea_showelectrode.m
@@ -72,7 +72,9 @@ for side=options.sides
             if ~err
                 break
             else
-                try
+                try                
+                    %recalculate as the tolerance/precision was not
+                    %satisfactory for this use case (will be loaded at tries==2)
                     if ~isfield(options,'patient_list') % single subject mode
                         [coords_mm,trajectory,markers]=ea_recalc_reco([],[],[options.root,options.patientname]);
                     else
@@ -82,12 +84,20 @@ for side=options.sides
                     elstruct.coords_mm=coords_mm;
                     elstruct.trajectory=trajectory;
                 catch
-                    warning(['There seems to be some inconsistency with the reconstruction of ',options.patientname,' that could not be automatically resolved. Please check data of this patient.']);
+                    if ~isfield(options,'patient_list') % single subject mode
+                        warning(['There seems to be some inconsistency with the reconstruction of ',options.patientname,' that could not be automatically resolved. Please check data of this patient.']);
+                    else
+                        warning(['There seems to be some inconsistency with the reconstruction of ',options.patient_list{pt},' that could not be automatically resolved. Please check data of this patient.']);
+                    end
                 end
             end
         end
         if err
-            warning(['There seems to be some inconsistency with the reconstruction of ',options.patientname,' that could not be automatically resolved. Please check data of this patient.']);
+            if ~isfield(options,'patient_list') % single subject mode
+                warning(['There seems to be some inconsistency with the reconstruction of ',options.patientname,' that could not be automatically resolved. Please check data of this patient.']);
+            else
+                warning(['There seems to be some inconsistency with the reconstruction of ',options.patient_list{pt},' that could not be automatically resolved. Please check data of this patient.']);
+            end
         end
         if options.d3.elrendering==2 % show a transparent electrode.
             aData=0.1;

--- a/helpers/ea_get_first_notempty_elmodel.m
+++ b/helpers/ea_get_first_notempty_elmodel.m
@@ -1,12 +1,12 @@
-function elmodel=ea_get_first_notempty_elmodel(reco___props)
-    % elmodel=ea_get_first_notempty_elmodel(reco.props)
+function [elmodel,first_notempty_side]=ea_get_first_notempty_elmodel(reco___props)
+    % [elmodel,first_notempty_side]=ea_get_first_notempty_elmodel(reco.props)
     % Copyright (C) 2020 Emory University, USA, School of Medicine
     % Enrico Opri
 
     elmodel=[];
     if ~isempty(reco___props)
-        for side=1:length(reco___props)
-            elmodel=reco___props(side).elmodel;
+        for first_notempty_side=1:length(reco___props)
+            elmodel=reco___props(first_notempty_side).elmodel;
             if ~isempty(elmodel)
                 break
             end

--- a/helpers/ea_getptopts.m
+++ b/helpers/ea_getptopts.m
@@ -28,7 +28,7 @@ end
 if exist([directory,filesep,'ea_reconstruction.mat'],'file')
     load([directory,filesep,'ea_reconstruction.mat']);
     try
-        options.elmodel=reco.props(1).elmodel;
+        options.elmodel=ea_get_first_notempty_elmodel(reco.props);
     catch
         options.elmodel='Medtronic 3389';
     end

--- a/helpers/gui/ea_load_pts.m
+++ b/helpers/gui/ea_load_pts.m
@@ -54,7 +54,6 @@ try
           end
        end
        try
-           %[~,locb] = ismember({reco.props(1).elmodel},handles.electrode_model_popup.String);
            elmodel=ea_get_first_notempty_elmodel(reco.props);
            [~,locb] = ismember({elmodel},handles.electrode_model_popup.String);
            set(handles.electrode_model_popup,'Value',locb);

--- a/lead_group.m
+++ b/lead_group.m
@@ -551,7 +551,7 @@ resultfig=ea_elvis(options,M.elstruct(ptidx));
 try % zoom on coordinates.
     coords={M.elstruct(:).coords_mm};
     for c=1:length(coords)
-        call(c,:)=mean([coords{c}{1};coords{c}{2}]);
+        call(c,:)=nanmean([coords{c}{1};coords{c}{2}]);
     end
     ea_zoomcenter(resultfig.CurrentAxes, mean(call), 5);
 catch

--- a/tools/export/pat2ply/ea_electrode2ply.m
+++ b/tools/export/pat2ply/ea_electrode2ply.m
@@ -3,12 +3,8 @@ function fv=ea_electrode2ply(directory,side,handles)
 options=ea_handles2options(handles);
 if exist([directory,'ea_reconstruction.mat'],'file')
     load([directory,'ea_reconstruction.mat']);
-    options.elmodel=reco.props(1).elmodel;
-    if isempty(options.elmodel)
-        try
-            options.elmodel=reco.props(2).elmodel;
-        end
-    end
+
+    options.elmodel=ea_get_first_notempty_elmodel(reco.props);
 end
 options=ea_resolve_elspec(options);
 [options.root,options.patientname]=fileparts(directory);

--- a/tools/export/pat2stl/ea_electrode2stl.m
+++ b/tools/export/pat2stl/ea_electrode2stl.m
@@ -3,12 +3,7 @@ function fv=ea_electrode2stl(directory,side,handles)
 options=ea_handles2options(handles);
 if exist([directory,'ea_reconstruction.mat'],'file')
     load([directory,'ea_reconstruction.mat']);
-    options.elmodel=reco.props(1).elmodel;
-    if isempty(options.elmodel)
-        try
-            options.elmodel=reco.props(2).elmodel;
-        end
-    end
+    options.elmodel=ea_get_first_notempty_elmodel(reco.props);
 end
 options=ea_resolve_elspec(options);
 [options.root,options.patientname]=fileparts(directory);


### PR DESCRIPTION
Fixing unilateral support for group analysis. 
Fixing statistics for group analysis (ensuring correct formatting in case that one side is missing). 
Refactoring code to use the ea_get_first_not_empty_elmodel method to ensure consistency (instead of using reco.props(1).elmodel, which is not always a valid/filled field).
