### PR TITLE
BUG: fixed the issue with empty/nan coords_acpc, patient selection in groupview and cosmetics

### DIFF
--- a/ea_showatlas.m
+++ b/ea_showatlas.m
@@ -117,20 +117,13 @@ for nativemni=nm % switch between native and mni space atlases.
             if ea_arenopoints4side(elstruct(el).coords_mm, miss_side)
                 %if the right side is missing, it will be already be "filled" with an empty or NaN array
                 %force to have empty values if side is not present (e.g. in R only case)
-                elstruct(el).coords_mm{miss_side}={};
-                if isfield(elstruct(el),'coords_acpc') 
-                    %this is to take care of the cases where
-                    %coords_acpc is NaN, or is a cell array (of N=sides
-                    %elements) which needs to be checked if empty or nan
-                    if iscell(elstruct(el).coords_acpc)
-                        if ea_arenopoints4side(elstruct(el).coords_acpc, miss_side)
-                            elstruct(el).coords_acpc{miss_side}={};
-                        end
-                    elseif ~isnan(elstruct(el).coords_acpc)
-                        elstruct(el).coords_acpc{miss_side}={};
+                elstruct(el).coords_mm{miss_side}=[];
+                if isfield(elstruct(el),'coords_acpc') && iscell(elstruct(el).coords_acpc)
+                    if ea_arenopoints4side(elstruct(el).coords_acpc, miss_side)
+                        elstruct(el).coords_acpc{miss_side}=[];
                     end
                 end
-                elstruct(el).trajectory{miss_side}={};
+                elstruct(el).trajectory{miss_side}=[];
                 
                 %this will create a second structure
                 elstruct(el).markers(miss_side).head=[];

--- a/ea_showatlas.m
+++ b/ea_showatlas.m
@@ -118,8 +118,17 @@ for nativemni=nm % switch between native and mni space atlases.
                 %if the right side is missing, it will be already be "filled" with an empty or NaN array
                 %force to have empty values if side is not present (e.g. in R only case)
                 elstruct(el).coords_mm{miss_side}={};
-                if isfield(elstruct(el),'coords_acpc') && ~isnan(elstruct(el).coords_acpc)
-                    elstruct(el).coords_acpc{miss_side}={};
+                if isfield(elstruct(el),'coords_acpc') 
+                    %this is to take care of the cases where
+                    %coords_acpc is NaN, or is a cell array (of N=sides
+                    %elements) which needs to be checked if empty or nan
+                    if iscell(elstruct(el).coords_acpc)
+                        if ea_arenopoints4side(elstruct(el).coords_acpc, miss_side)
+                            elstruct(el).coords_acpc{miss_side}={};
+                        end
+                    elseif ~isnan(elstruct(el).coords_acpc)
+                        elstruct(el).coords_acpc{miss_side}={};
+                    end
                 end
                 elstruct(el).trajectory{miss_side}={};
                 

--- a/ea_stimparams.m
+++ b/ea_stimparams.m
@@ -2248,15 +2248,58 @@ else % Ampere
     ea_show_percent(handles,options,2,'on'); % left hemisphere
 end
 
-% enable/disable panel based on sides that are present
+%% enable/disable panel based on sides that are present
 is_side_present=arrayfun(@(xside) ~ea_arenopoints4side(elstruct(actpt).trajectory, xside), [1,2]);%First element is R, second is L
 if is_side_present(1)>0%check if R side is present
     set(findall(handles.uipanel2, '-property', 'enable'), 'enable', 'on')
+    %fix color (ensure they are reloaded correctly)
+    try
+        handles.Rs1am.BackgroundColor=[1 1 1];%force redraw color
+        handles.Rs1am.BackgroundColor=[0.953 0.871 0.733];%orange 
+        handles.Rs2am.BackgroundColor=[1 1 1];%force redraw color
+        handles.Rs2am.BackgroundColor=[0.729 0.831 0.957];%blue 
+        handles.Rs3am.BackgroundColor=[1 1 1];%force redraw color
+        handles.Rs3am.BackgroundColor=[0.925 0.839 0.839];%red 
+        handles.Rs4am.BackgroundColor=[1 1 1];%force redraw color
+        handles.Rs4am.BackgroundColor=[0.757 0.867 0.776];%green 
+    catch
+        %for older versions of matlab (remove if dropping support of older Matlabs)
+        set(findall(handles.Rs1am, '-property', 'BackgroundColor'), 'BackgroundColor', [1 1 1]);%force redraw color
+        set(findall(handles.Rs1am, '-property', 'BackgroundColor'), 'BackgroundColor', [0.953 0.871 0.733]);%orange 
+        set(findall(handles.Rs2am, '-property', 'BackgroundColor'), 'BackgroundColor', [1 1 1]);%force redraw color
+        set(findall(handles.Rs2am, '-property', 'BackgroundColor'), 'BackgroundColor', [0.729 0.831 0.957]);%blue 
+        set(findall(handles.Rs3am, '-property', 'BackgroundColor'), 'BackgroundColor', [1 1 1]);%force redraw color
+        set(findall(handles.Rs3am, '-property', 'BackgroundColor'), 'BackgroundColor', [0.925 0.839 0.839]);%red 
+        set(findall(handles.Rs4am, '-property', 'BackgroundColor'), 'BackgroundColor', [1 1 1]);%force redraw color
+        set(findall(handles.Rs4am, '-property', 'BackgroundColor'), 'BackgroundColor', [0.757 0.867 0.776]);%green     
+    end
 else
     set(findall(handles.uipanel2, '-property', 'enable'), 'enable', 'off')
 end
 if is_side_present(2)>0%check if L side is present
     set(findall(handles.uipanel3, '-property', 'enable'), 'enable', 'on')
+    
+    %fix color (ensure they are reloaded correctly)
+    try
+        handles.Ls1am.BackgroundColor=[1 1 1];%force redraw color
+        handles.Ls1am.BackgroundColor=[0.953 0.871 0.733];%orange 
+        handles.Ls2am.BackgroundColor=[1 1 1];%force redraw color
+        handles.Ls2am.BackgroundColor=[0.729 0.831 0.957];%blue 
+        handles.Ls3am.BackgroundColor=[1 1 1];%force redraw color
+        handles.Ls3am.BackgroundColor=[0.925 0.839 0.839];%red 
+        handles.Ls4am.BackgroundColor=[1 1 1];%force redraw color
+        handles.Ls4am.BackgroundColor=[0.757 0.867 0.776];%green 
+    catch
+        %for older versions of matlab (remove if dropping support of older Matlabs)
+        set(findall(handles.Ls1am, '-property', 'BackgroundColor'), 'BackgroundColor', [1 1 1]);%force redraw color
+        set(findall(handles.Ls1am, '-property', 'BackgroundColor'), 'BackgroundColor', [0.953 0.871 0.733]);%orange 
+        set(findall(handles.Ls2am, '-property', 'BackgroundColor'), 'BackgroundColor', [1 1 1]);%force redraw color
+        set(findall(handles.Ls2am, '-property', 'BackgroundColor'), 'BackgroundColor', [0.729 0.831 0.957]);%blue 
+        set(findall(handles.Ls3am, '-property', 'BackgroundColor'), 'BackgroundColor', [1 1 1]);%force redraw color
+        set(findall(handles.Ls3am, '-property', 'BackgroundColor'), 'BackgroundColor', [0.925 0.839 0.839]);%red 
+        set(findall(handles.Ls4am, '-property', 'BackgroundColor'), 'BackgroundColor', [1 1 1]);%force redraw color
+        set(findall(handles.Ls4am, '-property', 'BackgroundColor'), 'BackgroundColor', [0.757 0.867 0.776]);%green 
+    end
 else
     set(findall(handles.uipanel3, '-property', 'enable'), 'enable', 'off')
 end

--- a/ea_stimparams.m
+++ b/ea_stimparams.m
@@ -1864,6 +1864,11 @@ if groupmode
         if length(actpt)>1 % more than one entry selected
             actpt=1;
         end
+        %to ensure active patient is non empty
+        %this can happen if you delete a patient, then add a new one, without clicking on the patient window
+        if isempty(actpt) 
+            actpt=1;
+        end
         setappdata(handles.stimfig,'actpt',actpt);
         % set grouploaded true is being done below.
     end
@@ -2906,6 +2911,12 @@ actpt=getappdata(handles.stimfig,'actpt');
 elstruct=getappdata(handles.stimfig,'elstruct');
 options=getappdata(handles.stimfig,'options');
 
+%to ensure active patient is non empty
+%this can happen if you delete a patient, then add a new one, without clicking on the patient window
+if isempty(actpt) 
+    actpt=1;
+end
+        
 if isempty(gS)
     clear gS
 end
@@ -2946,6 +2957,13 @@ gS=getappdata(handles.stimfig,'gS');
 actpt=getappdata(handles.stimfig,'actpt');
 elstruct=getappdata(handles.stimfig,'elstruct');
 options=getappdata(handles.stimfig,'options');
+
+%to ensure active patient is non empty
+%this can happen if you delete a patient, then add a new one, without clicking on the patient window
+if isempty(actpt) 
+    actpt=1;
+end
+
 if isempty(gS)
     clear gS
 end

--- a/ea_stimparams.m
+++ b/ea_stimparams.m
@@ -1864,7 +1864,8 @@ if groupmode
         if length(actpt)>1 % more than one entry selected
             actpt=1;
         end
-        %to ensure active patient is non empty
+        
+        %ensure active patient is non empty
         %this can happen if you delete a patient, then add a new one, without clicking on the patient window
         if isempty(actpt) 
             actpt=1;
@@ -2911,8 +2912,7 @@ actpt=getappdata(handles.stimfig,'actpt');
 elstruct=getappdata(handles.stimfig,'elstruct');
 options=getappdata(handles.stimfig,'options');
 
-%to ensure active patient is non empty
-%this can happen if you delete a patient, then add a new one, without clicking on the patient window
+%ensure active patient is non empty
 if isempty(actpt) 
     actpt=1;
 end
@@ -2958,8 +2958,7 @@ actpt=getappdata(handles.stimfig,'actpt');
 elstruct=getappdata(handles.stimfig,'elstruct');
 options=getappdata(handles.stimfig,'options');
 
-%to ensure active patient is non empty
-%this can happen if you delete a patient, then add a new one, without clicking on the patient window
+%ensure active patient is non empty
 if isempty(actpt) 
     actpt=1;
 end

--- a/helpers/gui/ea_refresh_lg.m
+++ b/helpers/gui/ea_refresh_lg.m
@@ -277,8 +277,17 @@ if 1    % ~isfield(M.ui,'lastupdated') || t-M.ui.lastupdated>240 % 4 mins time l
                 if ea_arenopoints4side(M.elstruct(pt).coords_mm, check_side)
                     %force to have empty values if side is not present
                     M.elstruct(pt).coords_mm{check_side}={};
-                    if ~isnan(M.elstruct(pt).coords_acpc)
-                        M.elstruct(pt).coords_acpc{check_side}={};
+                    if isfield(M.elstruct(pt),'coords_acpc') 
+                        %this is to take care of the cases where
+                        %coords_acpc is NaN, or is a cell array (of N=sides
+                        %elements) which needs to be checked if empty or nan
+                        if iscell(M.elstruct(pt).coords_acpc)
+                            if ea_arenopoints4side(M.elstruct(pt).coords_acpc, check_side)
+                                M.elstruct(pt).coords_acpc{check_side}={};
+                            end
+                        elseif ~isnan(M.elstruct(pt).coords_acpc)
+                            M.elstruct(pt).coords_acpc{check_side}={};
+                        end
                     end
                     M.elstruct(pt).trajectory{check_side}={};
                 

--- a/helpers/gui/ea_refresh_lg.m
+++ b/helpers/gui/ea_refresh_lg.m
@@ -276,20 +276,13 @@ if 1    % ~isfield(M.ui,'lastupdated') || t-M.ui.lastupdated>240 % 4 mins time l
             for check_side=1:num_sides %options.sides
                 if ea_arenopoints4side(M.elstruct(pt).coords_mm, check_side)
                     %force to have empty values if side is not present
-                    M.elstruct(pt).coords_mm{check_side}={};
-                    if isfield(M.elstruct(pt),'coords_acpc') 
-                        %this is to take care of the cases where
-                        %coords_acpc is NaN, or is a cell array (of N=sides
-                        %elements) which needs to be checked if empty or nan
-                        if iscell(M.elstruct(pt).coords_acpc)
-                            if ea_arenopoints4side(M.elstruct(pt).coords_acpc, check_side)
-                                M.elstruct(pt).coords_acpc{check_side}={};
-                            end
-                        elseif ~isnan(M.elstruct(pt).coords_acpc)
-                            M.elstruct(pt).coords_acpc{check_side}={};
+                    M.elstruct(pt).coords_mm{check_side}=[];
+                    if isfield(M.elstruct(pt),'coords_acpc') && iscell(M.elstruct(pt).coords_acpc)
+                        if ea_arenopoints4side(M.elstruct(pt).coords_acpc, check_side)
+                            M.elstruct(pt).coords_acpc{check_side}=[];
                         end
                     end
-                    M.elstruct(pt).trajectory{check_side}={};
+                    M.elstruct(pt).trajectory{check_side}=[];
                 
                     %this will create the missing structure
                     M.elstruct(pt).markers(check_side).head=[];


### PR DESCRIPTION
fixing handling of elstruct(pt).coords_acpc, in the case of unilateral leads (or when it is not computed)
ensured that actpt variable is not empty. this is needed in few edge cases: for example if you delete a patient and the readd another, without selecting the patient listview.
fixed color-restore for the voltage/amplitude sources textboxes in the stimulation parameter GUI, after they are re-enabled (e.g. after switching from a patient with unilateral lead to one with bilateral).