### PR TITLE
FIX + ENH detail viewer

### DIFF
--- a/ea_imshowpair.m
+++ b/ea_imshowpair.m
@@ -418,6 +418,24 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
                 MainImage=wiresIX;
             end
             set(ImHndl,'cdata',squeeze(Img(XImage,YImage,S,MainImage)));
+            
+%             try % image toolbox
+%                 ImHndl=imshow(squeeze(Img(XImage,YImage,S,MainImage)), [Rmin Rmax]);
+%             catch
+%                 ImHndl=imagesc(squeeze(Img(XImage,YImage,S,MainImage)), [Rmin Rmax]);
+%             end
+%             showhelptext(callingfunction);
+%             
+%             caxis([Rmin Rmax])
+%            
+%             if PostOpView && options.modality==1
+%                 SwitchPostop('update');
+%             else
+%                 set(ImHndl,'cdata',squeeze(Img(XImage,YImage,S,MainImage)))
+%             end
+%             
+%             set(ImHndl,'ButtonDownFcn', @mouseClick);
+            
         elseif (strcmpi(eventdata.Key,'g'))
             if size(Img,4)==4 && strfind(callingfunction,'normalization') % only do if grid is available.
                 if MainImage(1)==1
@@ -703,10 +721,10 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
         end
 
         try % image toolbox
-            ImHndl=imshow(squeeze(Img(XImage,YImage,S,MainImage)), [Rmin Rmax]);
+            ImHndl=imshow(squeeze(Img(XImage,YImage,S,1)), [Rmin Rmax]);
         catch
-            ImHndl=imagesc(squeeze(Img(XImage,YImage,S,MainImage)), [Rmin Rmax]);
-        end;
+            ImHndl=imagesc(squeeze(Img(XImage,YImage,S,1)), [Rmin Rmax]);
+        end
         showhelptext(callingfunction);
 
         if sno > 1
@@ -727,8 +745,6 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
         else
             set(ImHndl,'cdata',squeeze(Img(XImage,YImage,S,MainImage)))
         end
-
-        set (gcf, 'ButtonDownFcn', @mouseClick);
         set(ImHndl,'ButtonDownFcn', @mouseClick);
     end
 
@@ -756,10 +772,10 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
         hdl_im = axes('position',[0,0,1,1]);
 
         try % image toolbox
-            ImHndl=imshow(squeeze(Img(XImage,YImage,S,MainImage)), [Rmin Rmax]);
+            ImHndl=imshow(squeeze(Img(XImage,YImage,S,1)), [Rmin Rmax]);
         catch
-            ImHndl=imagesc(squeeze(Img(XImage,YImage,S,MainImage)), [Rmin Rmax]);
-        end;
+            ImHndl=imagesc(squeeze(Img(XImage,YImage,S,1)), [Rmin Rmax]);
+        end
         showhelptext(callingfunction);
 
         if sno > 1
@@ -780,7 +796,6 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
         else
             set(ImHndl,'cdata',squeeze(Img(XImage,YImage,S,MainImage)));
         end
-        set (gcf, 'ButtonDownFcn', @mouseClick);
         set(ImHndl,'ButtonDownFcn', @mouseClick);
     end
 
@@ -809,10 +824,10 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
         hdl_im = axes('position',[0,0,1,1]);
 
         try % image toolbox
-            ImHndl=imshow(squeeze(Img(XImage,YImage,S,MainImage)), [Rmin Rmax]);
+            ImHndl=imshow(squeeze(Img(XImage,YImage,S,1)), [Rmin Rmax]);
         catch
-            ImHndl=imagesc(squeeze(Img(XImage,YImage,S,MainImage)), [Rmin Rmax]);
-        end;
+            ImHndl=imagesc(squeeze(Img(XImage,YImage,S,1)), [Rmin Rmax]);
+        end
         showhelptext(callingfunction);
 
         if sno > 1
@@ -829,7 +844,6 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
         else
             set(ImHndl,'cdata',squeeze(Img(XImage,YImage,S,MainImage)))
         end
-        set (gcf, 'ButtonDownFcn', @mouseClick);
         set(ImHndl,'ButtonDownFcn', @mouseClick);
     end
 end

--- a/ea_imshowpair.m
+++ b/ea_imshowpair.m
@@ -138,6 +138,8 @@ WVFntSz = 9;
 BtnSz = 10;
 ChBxSz = 10;
 
+magnFactor = .1;    % standard magnification value that is used then left mouse button is clicked for the first time
+
 [Rmin Rmax] = WL2R(Win, LevV);
 
 hdl_im = axes('position',[0,0,1,1]);
@@ -196,6 +198,7 @@ set(gcf,'WindowButtonUpFcn', @mouseRelease)
 set(gcf,'ResizeFcn', @figureResized)
 set(gcf,'WindowButtonMotionFcn', @ButtonMotionCallback)
 set(gcf,'KeyPressFcn', @KeyPressCallback);
+
 
 % -=< Figure resize callback function >=-
     function figureResized(object, eventdata)
@@ -295,7 +298,7 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
                 'Pointer','crosshair', ...
                 'CurrentAxes',a2);
             set(a2, ...
-                'UserData',[1,0.1], ...  %magnification, frame size
+                'UserData',[1,magnFactor], ...  %magnification, frame size
                 'Color',get(a1,'Color'), ...
                 'Box','on');
             set(i2,'CData',Img(XImage,YImage,S,2));
@@ -382,13 +385,12 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
 
         if ~isempty(H)
             f1 = H(1); a1 = H(2); a2 = H(3);
-            a2_param = get(a2,'UserData');
             if (strcmp(get(f1,'CurrentCharacter'),'<') | strcmp(get(f1,'CurrentCharacter'),','))
-                a2_param(2) = a2_param(2)/1.2;
+                magnFactor = magnFactor/1.2;
             elseif (strcmp(get(f1,'CurrentCharacter'),'>') | strcmp(get(f1,'CurrentCharacter'),'.'))
-                a2_param(2) = a2_param(2)*1.2;
+                magnFactor = magnFactor*1.2;
             end
-            set(a2,'UserData',a2_param);
+            set(a2,'UserData',[1, magnFactor]);
         end
 
         if (strcmp(eventdata.Key,'leftarrow') || strcmp(eventdata.Key,'downarrow'))
@@ -408,7 +410,7 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
         elseif ~isnan(str2double(eventdata.Character))
             SwitchModality(eventdata.Key,eventdata.Modifier)
         elseif (strcmpi(eventdata.Key,'x'))
-            if MainImage(1)==1
+            xcif MainImage(1)==1
                 MainImage=wiresIX;
             elseif MainImage(1)==wiresIX(1)
                 MainImage=1;

--- a/ea_imshowpair.m
+++ b/ea_imshowpair.m
@@ -288,11 +288,15 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
             f1 = get(a1,'Parent');
 
             a2 = copyobj(a1,f1, 'legacy');
-
+            % helptext is also copied, we delete it here so it is not
+            % duplicated when when magnifying
+            delete(findall(a2,'Type','text')); 
+            
             i2 = get(a2,'Children');
             try
             i2=i2(2);
             end
+
             set(f1, ...
                 'UserData',[f1,a1,a2], ...
                 'Pointer','crosshair', ...
@@ -302,11 +306,6 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
                 'Color',get(a1,'Color'), ...
                 'Box','on');
             set(i2,'CData',Img(XImage,YImage,S,2));
-            xlabel(''); ylabel(''); zlabel(''); title('');
-            set(a1, ...
-                'Color',get(a1,'Color')*0.95);
-            set(f1, ...
-                'CurrentAxes',a1);
             set(f1,'WindowButtonMotionFcn', @ButtonMotionCallback)
             ButtonMotionCallback(f1);
 
@@ -418,24 +417,7 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
                 MainImage=wiresIX;
             end
             set(ImHndl,'cdata',squeeze(Img(XImage,YImage,S,MainImage)));
-            
-%             try % image toolbox
-%                 ImHndl=imshow(squeeze(Img(XImage,YImage,S,MainImage)), [Rmin Rmax]);
-%             catch
-%                 ImHndl=imagesc(squeeze(Img(XImage,YImage,S,MainImage)), [Rmin Rmax]);
-%             end
-%             showhelptext(callingfunction);
-%             
-%             caxis([Rmin Rmax])
-%            
-%             if PostOpView && options.modality==1
-%                 SwitchPostop('update');
-%             else
-%                 set(ImHndl,'cdata',squeeze(Img(XImage,YImage,S,MainImage)))
-%             end
-%             
-%             set(ImHndl,'ButtonDownFcn', @mouseClick);
-            
+                        
         elseif (strcmpi(eventdata.Key,'g'))
             if size(Img,4)==4 && strfind(callingfunction,'normalization') % only do if grid is available.
                 if MainImage(1)==1

--- a/ea_imshowpair.m
+++ b/ea_imshowpair.m
@@ -410,7 +410,7 @@ set(gcf,'KeyPressFcn', @KeyPressCallback);
         elseif ~isnan(str2double(eventdata.Character))
             SwitchModality(eventdata.Key,eventdata.Modifier)
         elseif (strcmpi(eventdata.Key,'x'))
-            xcif MainImage(1)==1
+            if MainImage(1)==1
                 MainImage=wiresIX;
             elseif MainImage(1)==wiresIX(1)
                 MainImage=1;


### PR DESCRIPTION
This PR:

fixes the following bugs in the detail viewer:

(i) when enabling X-Ray mode, the magnification window (when left-clicking) would show only a single color image
(ii) while X-Ray mode is enabled and switching the view plan and successively disabling X-Ray mode, the image would only show a single color image. Switching back to X-Ray mode would show the correct X-Ray overlay image again, but the user would be unable to switch back to 'normal' mode

enhances:

(i) helptext is no longer duplicated by the magnification window, so it the text looks nice, even when moving around the magnification window
(ii) the size of the magnification window is now stored, the user does not have to manually adjust it every time he/she left-clicks
(iii) some minor code cleanup