### PR TITLE
BUG: fix for ea_vta_overlap

### DIFF
--- a/helpers/ea_vta_overlap.m
+++ b/helpers/ea_vta_overlap.m
@@ -29,6 +29,10 @@ prefs = ea_prefs;
 efiedthreshold = prefs.machine.vatsettings.horn_ethresh*10^3;
 if contains(vta, 'efield')
     vtanii.img(vtanii.img<=efiedthreshold)=0;
+else
+    %make the VTA image as binary (for comparing overlap in the following code)
+    threshold_vta=max(vtanii.img(:)) * 0.5;
+    vtanii.img=double(vtanii.img>threshold_vta);
 end
 
 % Check if atlas is nifti file or xyz coordinates
@@ -51,6 +55,8 @@ switch side
 end
 
 if ~isempty(xyz)
+
+
     % Map XYZ coordinates into VTA image
     vox = round(ea_mm2vox(xyz, vta));
     filter = all(vox>[0,0,0],2) & all(vox<=size(vtanii.img),2); % Remove voxel out of bbox

--- a/helpers/ea_vta_overlap.m
+++ b/helpers/ea_vta_overlap.m
@@ -24,15 +24,15 @@ overlap = 0;
 vtanii = load_untouch_nii(vta);
 vtanii.img = double(vtanii.img);
 
-% Threshold the efield to avoid leak overlap
-prefs = ea_prefs;
-efiedthreshold = prefs.machine.vatsettings.horn_ethresh*10^3;
-if contains(vta, 'efield')
-    vtanii.img(vtanii.img<=efiedthreshold)=0;
-else
-    %make the VTA image as binary (for comparing overlap in the following code)
-    threshold_vta=max(vtanii.img(:)) * 0.5;
-    vtanii.img=double(vtanii.img>threshold_vta);
+if contains(vta, 'efield') % Input vta is efield_[right|left].nii
+    % Threshold the efield to avoid leak overlap
+    prefs = ea_prefs;
+    efiedthreshold = prefs.machine.vatsettings.horn_ethresh*10^3;
+    vtanii.img(vtanii.img<=efiedthreshold) = 0;
+else % Input vta is vat_[right|left].nii
+    % Make sure the vta image is really binary
+    threshold_vta = max(vtanii.img(:)) * 0.5;
+    vtanii.img = double(vtanii.img>threshold_vta);
 end
 
 % Check if atlas is nifti file or xyz coordinates
@@ -55,8 +55,6 @@ switch side
 end
 
 if ~isempty(xyz)
-
-
     % Map XYZ coordinates into VTA image
     vox = round(ea_mm2vox(xyz, vta));
     filter = all(vox>[0,0,0],2) & all(vox<=size(vtanii.img),2); % Remove voxel out of bbox


### PR DESCRIPTION
ea_vta_overlap had an overestimated overlap, due to missing threshold logic (basically it would end up summing values above 1 for each voxel, leading to gross overestimation (e.g. of 2^15 factor)
this is taken care in the case of the VAT, but not the eField (which was left as is)