### PR TITLE
Fixed color setting of vertices in .ply and .stl export

### DIFF
--- a/tools/export/pat2ply/ea_atlas2ply.m
+++ b/tools/export/pat2ply/ea_atlas2ply.m
@@ -30,7 +30,7 @@ for atl=1:length(atlasnames)
         for i=1:length(presets)
             cfv(cnt).vertices=atlases.roi{presets(i),side}.fv.vertices;
             cfv(cnt).faces=atlases.roi{presets(i),side}.fv.faces;
-            cfv(cnt).facevertexcdata=repmat(atlases.roi{presets(i),side}.color,size(cfv(cnt).faces,1),1);
+            cfv(cnt).facevertexcdata=repmat(atlases.roi{presets(i),side}.color,size(cfv(cnt).vertices,1),1);
             cnt = cnt + 1;
         end
     end

--- a/tools/export/pat2stl/ea_atlas2stl.m
+++ b/tools/export/pat2stl/ea_atlas2stl.m
@@ -30,7 +30,7 @@ for atl=1:length(atlasnames)
         for i=1:length(presets)
             cfv(cnt).vertices=atlases.roi{presets(i),side}.fv.vertices;
             cfv(cnt).faces=atlases.roi{presets(i),side}.fv.faces;
-            cfv(cnt).facevertexcdata=repmat(atlases.roi{presets(i),side}.color,size(cfv(cnt).faces,1),1);
+            cfv(cnt).facevertexcdata=repmat(atlases.roi{presets(i),side}.color,size(cfv(cnt).vertices,1),1);
             cnt = cnt + 1;
         end
     end


### PR DESCRIPTION
Bassam and I were able to fix the isse of wrong coloring of the anatomy and electrode meshes in patient's export to .ply and .stl

