### PR TITLE
ENH/BUGFIX for calculations of VAT stats.

### DIFF
--- a/helpers/ea_vta_overlap.m
+++ b/helpers/ea_vta_overlap.m
@@ -1,7 +1,16 @@
-function overlap = ea_vta_overlap(vta, atlas, side)
+function [vox_overlap, mm_overlap, vox_vta, mm_vta, vox_atlas, mm_atlas, overlap_voxsize, vta_voxsize, atlas_voxsize]  = ea_vta_overlap(vta, atlas, side)
 % Calculate the overlap between VTA and atlases (nifti or xyz coordinates)
-%
-% Return the overlap in VOXEL (NOT IN MM^3)
+% Return the overlap in VOXEL (vox_), and MM^3 (mm_)
+%Outputs:
+% -vox_overlap: number of voxels of the VTA (nifti) that overlaps with the atlas specified
+% -mm_overlap : volume of overlap between VTA and atlas
+% -vox_vta    : number of voxels of the VTA (nifti) used for the overlap estimation
+% -mm_vta     : volume of the VTA in mm^3 (estimated from the cached nifti)
+% -vox_atlas  : number of voxels composing the atlas (nifti) used for the overlap estimation
+% -mm_atlas   : volume of the atlas in mm^3
+% -overlap_voxsize : voxel size in mm^3 of the overlap volume used
+% -vta_voxsize     : voxel size in mm^3 of the overlap volume/nifti used
+% -atlas_voxsize   : voxel size in mm^3 of the overlap volume/nifti used
 
 % Split left/right side of the atlas
 if ~exist('side', 'var')
@@ -18,7 +27,8 @@ elseif isnumeric(side)
     end
 end
 
-overlap = 0;
+vox_overlap = 0;
+mm_overlap = 0;
 
 % Load VTA image
 vtanii = ea_load_nii(vta);
@@ -34,6 +44,8 @@ else % Input vta is vat_[right|left].nii
     threshold_vta = max(vtanii.img(:)) * 0.5;
     vtanii.img = double(vtanii.img>threshold_vta);
 end
+vta_voxsize = prod(ea_detvoxsize(vta));
+overlap_voxsize = vta_voxsize;
 
 % Check if atlas is nifti file or xyz coordinates
 if isnumeric(atlas)
@@ -45,6 +57,7 @@ elseif isfile(atlas)
     [xvox, yvox, zvox] = ind2sub(size(atlasnii.img), find(atlasnii.img(:)));
     xyz = ea_vox2mm([xvox, yvox, zvox], atlas);
 end
+atlas_voxsize = prod(ea_detvoxsize(atlas));
 
 % Only calculate for one side, suppose RAS orientation
 switch side
@@ -54,6 +67,11 @@ switch side
         xyz = xyz(xyz(:,1)<0,:);
 end
 
+vox_vta=sum(vtanii.img(:)>0);%store the number of voxels contained in the VTA/efield
+mm_vta=vox_vta.*vta_voxsize;%store in mm too
+vox_atlas=sum(atlasnii.img(:)>0);
+mm_atlas=vox_atlas.*atlas_voxsize;%store the atlas volume used in the overlap (in mm) too
+
 if ~isempty(xyz)
     % Map XYZ coordinates into VTA image
     vox = round(ea_mm2vox(xyz, vta));
@@ -62,6 +80,8 @@ if ~isempty(xyz)
         vox = vox(filter, :);
         ind = unique(sub2ind(size(vtanii.img), vox(:,1), vox(:,2), vox(:,3)));
         % Checking overlap for image1
-        overlap = sum(vtanii.img(ind));
+        vox_overlap = sum(vtanii.img(ind));
+        
+        mm_overlap=vox_overlap.*overlap_voxsize;
     end
 end


### PR DESCRIPTION
Additionally computes and stores nWithinAtlasIntersection (% of VTA/Atlas ROI overlap as a fraction of the atlas ROI volume).
Added also the .AtlasVolume in mm^3 for comparison. Both are stored in each ea_stats.stimulation(thisstim).vat(side,vat).
The vat.volume is now overwritten with the VTA/VAT volume computed by ea_vta_overlap (from the nifti cached file) for consistency with the overlap/atlas volume computation.