### PR TITLE
FIX: Pacer with ANTS+subcortical refine

### DIFF
--- a/ea_genctmask.m
+++ b/ea_genctmask.m
@@ -15,6 +15,9 @@ switch coregct_method_applied{end}
     case 'ea_coregctmri_ants'
         coregs=dir([directory,ea_stripext(options.prefs.prenii_unnormalized),'2',ea_stripext(options.prefs.rawctnii_unnormalized),'_ants*.mat']);
         suffix=strrep(coregs(end).name,[ea_stripext(options.prefs.prenii_unnormalized),'2',ea_stripext(options.prefs.rawctnii_unnormalized)],'');
+        case 'ea_coregctmri_ants_refine'
+        coregs=dir([directory,ea_stripext(options.prefs.prenii_unnormalized),'2',ea_stripext(options.prefs.rawctnii_unnormalized),'_ants*.mat']);
+        suffix=strrep(coregs(end).name,[ea_stripext(options.prefs.prenii_unnormalized),'2',ea_stripext(options.prefs.rawctnii_unnormalized)],'');
     case 'ea_coregctmri_fsl'
         coregs=dir([directory,ea_stripext(options.prefs.prenii_unnormalized),'2',ea_stripext(options.prefs.rawctnii_unnormalized),'_flirt*.mat']);
         suffix=strrep(coregs(end).name,[ea_stripext(options.prefs.prenii_unnormalized),'2',ea_stripext(options.prefs.rawctnii_unnormalized)],'');


### PR DESCRIPTION
This PR fixes Pacer not running when ANTs+Subcortical refine was used as coregistration method for CT to MRI