### PR TITLE
FIX: diode medtronic sensight angle issue and handling edge cases for extraction of the intensity profile from marker artifact

### DIFF
--- a/ea_diode_medtronic.m
+++ b/ea_diode_medtronic.m
@@ -266,12 +266,17 @@ for x=1:2
     [valleyfft{x},~] = ea_diode_intensitypeaksFFT(-intensity{x},2);
     windowwidth = 20;
     for k = 1:length(valleyfft{x})
-        %variable window
+        %window vals get wrapped around to have values between 1 and 360
         window_var=[(valleyfft{x}(k)-windowwidth):(valleyfft{x}(k)+windowwidth)];
-        window_var(window_var<1)=[];
+        window_var(window_var<1)=window_var(window_var<1)+360;
+        window_var(window_var>360)=window_var(window_var<1)-360;
         
         [~,loctemp] = min(intensity{x}(window_var));
-        valleyreal{x}(k) = (window_var(1)-1)+loctemp;
+        val_ii=window_var(1)+loctemp;
+        %idxs get wrapped around to have values between 1 and 360
+        val_ii(val_ii<1)=val_ii(val_ii<1)+360;
+        val_ii(val_ii>360)=val_ii(val_ii>360)-360;
+        valleyreal{x}(k) = val_ii;
         clear loctemp
     end
     %% Detect angles of the white streak of the marker (only for intensityprofile-based ambiguity features)    

--- a/ea_diode_medtronic.m
+++ b/ea_diode_medtronic.m
@@ -266,8 +266,12 @@ for x=1:2
     [valleyfft{x},~] = ea_diode_intensitypeaksFFT(-intensity{x},2);
     windowwidth = 20;
     for k = 1:length(valleyfft{x})
-        [~,loctemp] = min(intensity{x}(valleyfft{x}(k)-windowwidth:valleyfft{x}(k)+windowwidth));
-        valleyreal{x}(k) = valleyfft{x}(k)-windowwidth+loctemp;
+        %variable window
+        window_var=[(valleyfft{x}(k)-windowwidth):(valleyfft{x}(k)+windowwidth)];
+        window_var(window_var<1)=[];
+        
+        [~,loctemp] = min(intensity{x}(window_var));
+        valleyreal{x}(k) = (window_var(1)-1)+loctemp;
         clear loctemp
     end
     %% Detect angles of the white streak of the marker (only for intensityprofile-based ambiguity features)    
@@ -413,7 +417,7 @@ else
 end
 
 %% Take peak
-peakangle(side) = rad2deg(roll);
+peakangle(side) = roll;%keep in radians
 realsolution = 1;
 
 dirlevelnew_mm = dirlevelnew_mm + (unitvector_mm * checkslices(darkstarslice(realsolution)));
@@ -608,9 +612,9 @@ imagesc(finalslice)
 axis equal
 axis off
 caxis([1500 3000])
-if peakangle(side) < 90 || peakangle(side) > 270
+if peakangle(side) < pi/2 || peakangle(side) > 3/2*pi
     quiver(round(size(finalslice,2)/2), round(size(finalslice,1)/2).*1.7, -round(size(finalslice,1)/8), 0, 2,'LineWidth',1.5,'Color','g','MaxHeadSize',2)
-elseif peakangle(side) >= 90 && peakangle(side) <=270
+elseif peakangle(side) >= pi/2 && peakangle(side) <=3/2*pi
     quiver(round(size(finalslice,2)/2), round(size(finalslice,1)/2).*1.7, +round(size(finalslice,1)/8), 0, 2,'LineWidth',1.5,'Color','g','MaxHeadSize',2)
 end
 scatter(ax3,round(size(finalslice,2)/2),round(size(finalslice,1)/2).*1.7,[],[0 0.4470 0.7410],'filled')


### PR DESCRIPTION
## When reporting in the viewer, some angle variables are converted two times from rad2deg, resulting in a wrong angle
For example tempangle and peakangle were converted multiple times with rad2deg, which for example caused issues as argument of camorbit and ea_diode_rollpitchyaw, or within the "detect orientation window" in the Localize DBS electrode.

## Additionally, there is an issue when reconstructing orientation of medtronic lead, that is triggered in some edge cases.
Solved by making a variable window for finding local minima within the extraction of the intensity profile from marker artifact

Triggered error:

    Reconstructing rotation of right lead!
    Array indices must be positive integers or logical values.
    
    Error in ea_diode_medtronic (line 269)
            [~,loctemp] = min(intensity{x}(valleyfft{x}(k)-windowwidth:valleyfft{x}(k)+windowwidth));
    
    Error in ea_diode_main (line 109)
            [roll_y,y,~] = ea_diode_medtronic(side,ct,head_mm,unitvector_mm,tmat_vx2mm,options.elspec);
    
    Error in ea_manualreconstruction>ea_autorotate (line 615)
    orientation = ea_diode_main(options);
     
    Error while evaluating PushTool ClickedCallback.