### PR TITLE
BUG: fixed when atlas contains fiber tracts the 3D atlas show/hide menu does not work

### DIFF
--- a/helpers/gui/ea_getsubindex.m
+++ b/helpers/gui/ea_getsubindex.m
@@ -3,12 +3,18 @@ function [ixs,ixt]=ea_getsubindex(sel,sidec,surfs,togglebuttons,uselabelname,atl
 sel = char(sel);
 
 if regexp(sel, '<HTML><BODY>')
-    [sel ~] = regexp(sel,'(?:&nbsp;)+(.*)</FONT></BODY></HTML>','tokens','match');
+    [sel, ~] = regexp(sel,'(?:&nbsp;)+(.*)</FONT></BODY></HTML>','tokens','match');
     sel = sel{1}{1};
 end
 if uselabelname ~= 0
     [~, nsel] = ismember(sel,atlases.labels{uselabelname});
-    [~, sel] = ea_niifileparts(atlases.names{nsel});
+    if isfield(atlases,'tissuetypes') && (atlases.tissuetypes(nsel)==2)
+        % Use fileparts to extract the name, fiber atlas files are
+        % always named as XXX.mat
+        [~, sel] = fileparts(atlases.names{nsel});
+    else
+        [~, sel] = ea_niifileparts(atlases.names{nsel});
+    end
 end
 
 for p=1:length(surfs)


### PR DESCRIPTION
This is caused by ea_getsubindex, which uses as name for the structure the what obtained with ea_niifileparts, which however does not strip the extension from a file terminating in .mat, and returns it unaltered.
Fiber tracts are now handled separately from nii atlas files.