### PR TITLE
FIX: get current pat subj struct in ea_autocoord

### DIFF
--- a/ea_autocoord.m
+++ b/ea_autocoord.m
@@ -20,7 +20,7 @@ if isfield(options, 'leadfigure')
     subjId = getappdata(options.leadfigure, 'subjId');
     if ~isempty(bids)
         options.bids = bids;
-        options.subj = bids.getSubj(subjId{1}, options.modality);
+        options.subj = bids.getSubj(subjId{options.pat}, options.modality);
     end
 end
 


### PR DESCRIPTION
Hi, not sure if this is a bug or not.

Shouldn't we get the current subj struct when we iterate over ea_autocoord?

Discard if is not necessary

Thanks!