### PR TITLE
FIX: index not found when sorting preop-images

### DIFF
--- a/ea_detsides.m
+++ b/ea_detsides.m
@@ -1,6 +1,6 @@
 function options = ea_detsides(options)
 
-reconFile = fullfile(options.root, options.patientname, 'reconstruction', [options.patientname, '_desc-reconstruction.mat']);
+reconFile = fullfile(options.subj.reconDir, [options.subj.subjId, '_desc-reconstruction.mat']);
 if isfile(reconFile)
     load(reconFile, 'reco');
     sides = [];

--- a/helpers/BIDSFetcher.m
+++ b/helpers/BIDSFetcher.m
@@ -246,11 +246,11 @@ classdef BIDSFetcher
             preniiOrder = obj.settings.prenii_order;
             templateOrder = fieldnames(obj.spacedef.norm_mapping)';
             preopImageOrder = [preniiOrder, setdiff(templateOrder, preniiOrder, 'stable')];
-
+            
             % Set pre-op anat images according to pre-defined orders
             for i=1:length(preopImageOrder)
                 % Find the index in the present images
-                idx = find(ismember(regexp(modality, '(?<=[^\W_]+_)[^\W_]+', 'match', 'once'), preopImageOrder{i}));
+                idx = find(contains(modality, preopImageOrder{i}));
                 if ~isempty(idx)
                     [~, ind] = ea_sortalike(lower(regexp(modality(idx), '[^\W_]+(?=_[^\W_]+)', 'match', 'once')), {'iso', 'ax', 'cor', 'sag'});
                     idx = idx(ind);
@@ -272,6 +272,7 @@ classdef BIDSFetcher
                     preopAnat.(modality{i}) = images{i};
                 end
             end
+
         end
 
         function postopAnat = getPostopAnat(obj, subjId, preferMRCT)

--- a/helpers/export/ea_screenshots.m
+++ b/helpers/export/ea_screenshots.m
@@ -20,10 +20,11 @@ viewsets=load([ea_getearoot,'helpers',filesep,'export',filesep,'ea_exportviews']
 options.atlasset=viewsets.(target).atlas;
 options.sidecolor=1;
 options.writeoutstats=0;
+options.patientname = options.subj.subjId;
 resultfig=ea_elvis(options);
 
-if ~exist([options.root,options.patientname,filesep,'export',filesep,'views'],'dir')
-    mkdir([options.root,options.patientname,filesep,'export',filesep,'views']);
+if ~exist(fullfile(options.subj.subjDir, 'export', 'views'),'dir')
+    mkdir(fullfile(options.subj.subjDir, 'export', 'views'));
 end
 
 views=viewsets.(target).views;
@@ -35,6 +36,6 @@ for view=1:length(views)
     set(0,'CurrentFigure',resultfig);
     ea_view(views(view).v,resultfig);
     set(0,'CurrentFigure',resultfig);
-    ea_screenshot([options.root,options.patientname,filesep,'export',filesep,'views',filesep,'view_',sprintf('%03.0f',view),'.png'],'ld', resultfig);
+    ea_screenshot(fullfile(options.subj.subjDir, 'export', 'views', ['view_',sprintf('%03.0f',view),'.png']),'ld', resultfig);
 end
 close(resultfig);

--- a/tools/export/ea_exportpat.m
+++ b/tools/export/ea_exportpat.m
@@ -7,7 +7,7 @@ if strcmp(uipatdir{1},'No Patient Selected')
 end
 disp('Exporting Results...');
 for pt=1:length(uipatdir)
-    try
+%     try
         if ~exist([uipatdir{pt}, filesep, 'export', filesep, lower(exptype)],'dir')
             mkdir([uipatdir{pt}, filesep, 'export', filesep, lower(exptype)]);
         end
@@ -47,8 +47,8 @@ for pt=1:length(uipatdir)
                     warndlg('Upload failed.','Upload error.');
                 end
         end
-    catch
-        keyboard
-        msgbox(['Export for pt: ',uipatdir{pt},' failed.']);
-    end
+%     catch
+%         keyboard
+%         msgbox(['Export for pt: ',uipatdir{pt},' failed.']);
+%     end
 end


### PR DESCRIPTION
Reopening this PR (last one got deleted due to branch renaming on my end).

Sorting of preop images based on order did not return an index, thus the anchor modality would be set incorrectly.