### PR TITLE
Skip failing seed for lead_mapper functional connectiviy calculation

### DIFF
--- a/connectomics/mapper/cs_fmri_conseed_seed_tc.m
+++ b/connectomics/mapper/cs_fmri_conseed_seed_tc.m
@@ -412,7 +412,12 @@ for s=1:size(seedfn,1) % subtract 1 in case of pmap command
     end
 
     % export T
-    [~,~,~,tstat]=ttest(fX{s}');
+    try
+        [~,~,~,tstat]=ttest(fX{s}');
+    catch
+        warning(strcat(seedfn{s}, ' failed. Please run this channel again and adjust parameters. Moving on to next channel.'));
+        continue
+    end
     tmap=dataset.vol.space;
     tmap.img(:)=0;
     tmap.dt(1) = 16;


### PR DESCRIPTION
For the lead_mapper functional connectivity run, seeds can fail with the following exception:
<img width="1057" alt="func_matlab_error" src="https://user-images.githubusercontent.com/38216460/182032288-608fb09d-7ce8-4c34-bc68-085c7cafc8e5.png">

I wrote a simple try catch clause that catches this exception and continues to the next seed.

Note that soemthing similar is already done in `ea_run.m`:

```
try
    ea_autocoord(options);
catch
    warning([options.patientname,' failed. Please run this patient again and adjust parameters. Moving on to next patient.' ]);
end
```

And for running structural connectiviy, the estimation also does not stop if no fibers are being found:

<img width="1060" alt="struct_matlab_error" src="https://user-images.githubusercontent.com/38216460/182032603-0d9ed560-0e57-4cfa-aa79-0215e93d9df6.png">

So it would be great to add it for the functional connectivity as well. 

Note that I could not test this extensively.