### PR TITLE
ENH include brain shift correction for visualization and postop norma…

### DIFF
--- a/ea_assignbackdrop.m
+++ b/ea_assignbackdrop.m
@@ -85,7 +85,7 @@ if strcmp(bdstring, 'list')
 
 elseif regexp(bdstring, ['^', subpat,' Pre-OP \(.*\)$'])    % pattern: "Patient Pre-OP (*)"
     whichpreop = (regexp(bdstring, ['(?<=^', subpat,' Pre-OP \()(.*)(?=\))'],'match','once'));
-    options = ea_switchpost2pre(options, native, whichpreop);
+    options = ea_switchpost2pre(options, native, whichpreop); % dangerous, likely best to replace sooner or later - took me a while to read
     [Vtra,Vcor,Vsag] = assignpatspecific(options, native);
     varargout{1} = Vtra;
     varargout{2} = Vcor;
@@ -93,9 +93,17 @@ elseif regexp(bdstring, ['^', subpat,' Pre-OP \(.*\)$'])    % pattern: "Patient 
 
 elseif strcmp(bdstring, [subpat, ' Post-OP'])
     [Vtra,Vcor,Vsag] = assignpatspecific(options, native);
+    if exist(options.subj.brainshift.transform.scrf,'file') % apply brainshift correction to files on the fly.
+        scrf=load(options.subj.brainshift.transform.scrf);
+        Vtra.mat=scrf.mat*Vtra.mat;
+        Vcor.mat=scrf.mat*Vcor.mat;
+        Vsag.mat=scrf.mat*Vsag.mat;
+    end
+
     varargout{1} = Vtra;
     varargout{2} = Vcor;
     varargout{3} = Vsag;
+    
 
 elseif strcmp(bdstring, 'BigBrain 100 um ICBM 152 2009b Sym (Amunts 2013)')
 %     if ~ea_checkinstall('bigbrain',0,1)
@@ -144,10 +152,13 @@ if native
                 Vsag = Vtra;
             end
         case 2 % CT
-            Vtra = spm_vol(options.subj.coreg.anat.postop.tonemapCT);
+            Vtra = spm_vol(options.subj.coreg.anat.postop.CT);
             Vcor = Vtra;
             Vsag = Vtra;
     end
+
+
+
 else
     switch options.modality
         case 1 % MR

--- a/ea_segment_electrode.m
+++ b/ea_segment_electrode.m
@@ -4,17 +4,17 @@ directory=[options.root,options.patientname,filesep];
 if options.native
     switch options.modality
         case 1
-            elnii=options.prefs.tranii_unnormalized;
+            elnii = options.subj.coreg.anat.postop.ax_MRI;
         case 2
-            elnii=options.prefs.ctnii_coregistered;
+            elnii = options.subj.coreg.anat.postop.CT;
     end
     elssubf='native';
 else
     switch options.modality
         case 1
-            elnii=options.prefs.ltranii;
+            elnii=options.subj.norm.anat.postop.ax_MRI;
         case 2
-            elnii=options.prefs.gctnii;
+            elnii=options.subj.norm.anat.postop.CT;
     end
     elssubf='template';
 end
@@ -34,7 +34,14 @@ switch onoff
             elseg.Visible='on';
         else
             % check if segmentation exists
-            nii=ea_load_nii([directory,elnii]);
+            nii=ea_load_nii(elnii);
+
+            if options.native
+                if exist(options.subj.brainshift.transform.scrf,'file') % apply brainshift correction to files on the fly.
+                    scrf=load(options.subj.brainshift.transform.scrf);
+                    nii.mat=scrf.mat*nii.mat;
+                end
+            end
 
             if options.modality==1 % not yet implemented for MR.
                 nii.img=-nii.img;

--- a/ext_libs/ANTs/ea_ants_apply_transforms.m
+++ b/ext_libs/ANTs/ea_ants_apply_transforms.m
@@ -100,10 +100,33 @@ if nargin == 1
 
     switch options.modality
         case 1 % MR
-            input = [input; struct2cell(options.subj.coreg.anat.postop)];
+            if exist(options.subj.brainshift.transform.scrf,'file') % apply brainshift correction to postop files on the fly.
+                fn=fieldnames(options.subj.coreg.anat.postop);
+                for postopfile=1:length(fn)
+                    uuid=ea_generate_uuid;
+                    copyfile(options.subj.coreg.anat.postop.(fn{postopfile}),[ea_getleadtempdir,uuid,'.nii']);
+                    nii=ea_load_nii([ea_getleadtempdir,uuid,'.nii']);
+                    scrf=load(options.subj.brainshift.transform.scrf);
+                    nii.mat=scrf.mat*nii.mat;
+                    ea_write_nii(nii);
+                    input = [input; [ea_getleadtempdir,uuid,'.nii']];
+                end
+            else
+                input = [input; struct2cell(options.subj.coreg.anat.postop)];
+            end
             output = [output; struct2cell(options.subj.norm.anat.postop)];
         case 2 % CT
-            input = [input; options.subj.coreg.anat.postop.CT];
+            if exist(options.subj.brainshift.transform.scrf,'file') % apply brainshift correction to postop files on the fly.
+                uuid=ea_generate_uuid;
+                copyfile(options.subj.coreg.anat.postop.CT,[ea_getleadtempdir,uuid,'.nii']);
+                nii=ea_load_nii([ea_getleadtempdir,uuid,'.nii']);
+                scrf=load(options.subj.brainshift.transform.scrf);
+                nii.mat=scrf.mat*nii.mat;
+                ea_write_nii(nii);
+                input = [input; [ea_getleadtempdir,uuid,'.nii']];
+            else
+                input = [input; options.subj.coreg.anat.postop.CT];
+            end
             output = [output; options.subj.norm.anat.postop.CT];
     end
 end


### PR DESCRIPTION
…lization

…had wanted to do this a long time: The scrf matrix (from brain shift correction) will now be applied to postop data visualization in both native and MNI spaces (in MNI space only when regenerating the data).

See screenshots for before / after ping @Kinway25 (we had talked about this early on).

Would need to also add to ea_fsl_apply_normalization / ea_spm_apply_normalization – ran out of time. Thx.

<img width="1043" alt="before" src="https://user-images.githubusercontent.com/1291036/183761702-36a2ac1c-c424-4d69-a1c9-b4735306d4ea.png">
<img width="1101" alt="after" src="https://user-images.githubusercontent.com/1291036/183761704-0e257738-992f-4f55-9e83-bb0f632b5f80.png">

