### PR TITLE
UPD works on matrices not only column vectors

### DIFF
--- a/ext_libs/nan/ea_nanzscore.m
+++ b/ext_libs/nan/ea_nanzscore.m
@@ -1,17 +1,25 @@
 function z=ea_nanzscore(varargin)
 
 data=varargin{1};
-datawonan = data(~isnan(data));
+
 dorobust=0;
 if nargin>1
-    if strcmp(varargin{2},'robust');
+    if strcmp(varargin{2},'robust')
         dorobust=1;
     end
 end
-if dorobust
-    datamean = ea_robustmean(datawonan);
-else
-    datamean = mean(datawonan);
-end
-datasd = std(datawonan);
-z = (data-datamean)/datasd;
+
+[datamean, datasd] = deal(zeros(1, size(data, 2)));
+for ci = 1:size(data, 2)
+    datawonan = data(:, ci); 
+    datawonan = datawonan(~isnan(datawonan));
+    if dorobust
+        datamean(ci) = ea_robustmean(datawonan);
+    else
+        datamean(ci) = mean(datawonan);
+    end
+    datasd(ci) = std(datawonan); 
+end 
+
+z = ( data - repmat(datamean, size(data, 1), 1) ) ...
+    ./ repmat(datasd, size(data, 1), 1); 

--- a/ext_libs/nan/ea_nanzscore.m
+++ b/ext_libs/nan/ea_nanzscore.m
@@ -1,4 +1,9 @@
 function z=ea_nanzscore(varargin)
+% Computes zscores for input data 
+%
+% data : a row vector, column vector, or (column-oriented) matrix 
+% if data is a matrix, z-scores are computed over columns 
+% 'robust' : if set as second argument, mean is computed excluding outliers
 
 data=varargin{1};
 
@@ -9,17 +14,29 @@ if nargin>1
     end
 end
 
-[datamean, datasd] = deal(zeros(1, size(data, 2)));
-for ci = 1:size(data, 2)
-    datawonan = data(:, ci); 
-    datawonan = datawonan(~isnan(datawonan));
+if isvector(data) 
+    datawonan = data(~isnan(data));
     if dorobust
-        datamean(ci) = ea_robustmean(datawonan);
+        datamean = ea_robustmean(datawonan);
     else
-        datamean(ci) = mean(datawonan);
+        datamean = mean(datawonan);
     end
-    datasd(ci) = std(datawonan); 
-end 
+    datasd = std(datawonan);
+    z = (data-datamean)/datasd;
 
-z = ( data - repmat(datamean, size(data, 1), 1) ) ...
-    ./ repmat(datasd, size(data, 1), 1); 
+elseif ismatrix(data) 
+    [datamean, datasd] = deal(zeros(1, size(data, 2)));
+    for ci = 1:size(data, 2)
+        datawonan = data(:, ci); 
+        datawonan = datawonan(~isnan(datawonan));
+        if dorobust
+            datamean(ci) = ea_robustmean(datawonan);
+        else
+            datamean(ci) = mean(datawonan);
+        end
+        datasd(ci) = std(datawonan); 
+    end 
+    
+    z = ( data - repmat(datamean, size(data, 1), 1) ) ...
+        ./ repmat(datasd, size(data, 1), 1); 
+end


### PR DESCRIPTION
This function is used on a matrix of clinical scores rather than vectors for the PCA option of the fiberfiltering tool, such as the z-score computation was wrong. Made the function work for both column vectors and matrices with one score per column.