### PR TITLE
Fix: doubling amps if VTAs are mirrrored

### DIFF
--- a/classes/sweetspotmapping/ea_sweetspot_calcstats.m
+++ b/classes/sweetspotmapping/ea_sweetspot_calcstats.m
@@ -82,8 +82,14 @@ for group=groups
                         amps(k,2) = obj.M.S(k).Ls1.amp;
                     end
                 end
+                
+                if obj.mirrorsides
+                    amps = [amps;amps];
+                end
+
                 %get VTA Size
                 VTAsize(:,side) = sum(gval{side},2);
+                VTAsize((VTAsize==0))=nan; % will prevent division by zero issue in case of empty VTAs
 
                 %% define null-hypothesis for statistical testing
                 switch obj.stat0hypothesis


### PR DESCRIPTION
Copied from the dev branch