### PR TITLE
Autofill ROI Colors when adding multiple ROI objects to the scene

### DIFF
--- a/common/ea_prefs_default.m
+++ b/common/ea_prefs_default.m
@@ -164,6 +164,10 @@ prefs.d3.ceilinglightcolor = [1, 0.9, 0.9]; % pinkish '#FFE6E6'
 prefs.d3.rightlightcolor = [1, 0.9, 0.7]; % yellowish '#FFE6B3'
 prefs.d3.leftlightcolor = [0.9, 0.9, 1]; % bluish '#E6E6FF'
 
+% Loading ROIs to resultfig
+prefs.d3.roi.autofillcolor = 1; % 1 to autofill color 
+prefs.d3.roi.defaultcolormap = 'turbo'; % default colormap is turbo, see help graph3d for other options
+
 %% Video export
 prefs.video.path=[-90,10
                   -110,10

--- a/common/ea_prefs_default.m
+++ b/common/ea_prefs_default.m
@@ -164,9 +164,9 @@ prefs.d3.ceilinglightcolor = [1, 0.9, 0.9]; % pinkish '#FFE6E6'
 prefs.d3.rightlightcolor = [1, 0.9, 0.7]; % yellowish '#FFE6B3'
 prefs.d3.leftlightcolor = [0.9, 0.9, 1]; % bluish '#E6E6FF'
 
-% Loading ROIs to resultfig
+% Auto fill ROI color (in case multiple ROIs selected)
 prefs.d3.roi.autofillcolor = 1; % 1 to autofill color 
-prefs.d3.roi.defaultcolormap = 'turbo'; % default colormap is turbo, see help graph3d for other options
+prefs.d3.roi.defaultcolormap = 'parula'; % default colormap is parula, see help colormap for other options
 
 %% Video export
 prefs.video.path=[-90,10

--- a/ea_addobj.m
+++ b/ea_addobj.m
@@ -7,17 +7,45 @@ if isempty(addht)
 end
 
 if iscell(obj) % dragndrop for tract and roi, 'obj' is a cell of the files
-    if all(cellfun(@numel, regexp(obj, '(\.mat|\.trk)$', 'match', 'once')))
+    if all(cellfun(@numel, regexp(obj, '(\.mat|\.trk)$', 'match', 'once'))) %tract
         for i=1:length(obj)
             addfibertract(obj{i}, resultfig, addht, [], 0, options);
         end
-    elseif all(cellfun(@numel, regexp(obj, '(\.nii|\.nii\.gz)$', 'match', 'once')))
+    
+    elseif all(cellfun(@numel, regexp(obj, '(\.nii|\.nii\.gz)$', 'match', 'once'))) %roi
         pobj.plotFigureH = resultfig;
         pobj.htH = addht;
-        for i=1:length(obj)
-            pobj.color = ea_uisetcolor;
-            ea_roi(obj{i}, pobj);
-        end
+         if options.d3.roi.autofillcolor && length(obj)>1 % i.e. multiple roi's selected
+            if length(obj)<=32
+                str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(32);');
+                eval(str2eval)
+            else
+                str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(',num2str(length(roiName)),');');
+                eval(str2eval)
+            end
+            options.d3.roi.colormap = c;
+            for i=1:length(obj)
+                pobj.color = options.d3.roi.colormap(i,:);
+                ea_roi(obj{i}, pobj);
+            end
+        elseif options.d3.roi.autofillcolor && length(obj)==1
+            for i=1:length(obj)
+                pobj.color = ea_uisetcolor;
+                ea_roi(obj{i}, pobj);
+            end
+         else
+             for i=1:length(obj)
+                 pobj.color = ea_uisetcolor;
+                 ea_roi(obj{i}, pobj);
+             end
+         end
+
+
+
+        
+
+
+
     elseif all(cellfun(@numel, regexp(obj, '(\.fibfilt)$', 'match', 'once')))
         for i=1:length(obj)
             ea_discfiberexplorer(obj{i}, resultfig);
@@ -58,20 +86,42 @@ else  % uigetfile, 'obj' is the type of the files to be selected
         case 'roi' % atlas
             % open dialog
             [roiName, roiPath] = uigetfile({'*.nii';'*.nii.gz'},'Choose .nii image to add to scene...',startPath,'MultiSelect','on');
+            
             if isnumeric(roiName) % User pressed cancel, roiName is 0
                 return
             else
                 if ischar(roiName)
                     roiName = {roiName};
                 end
-
+                
                 pobj.plotFigureH = resultfig;
                 pobj.htH = addht;
-                for fi=1:length(roiName)
-                    pobj.color = ea_uisetcolor;
-                    ea_roi([roiPath, roiName{fi}], pobj);
+                if options.d3.roi.autofillcolor && length(roiName)>1 % i.e. multiple roi's selected
+                    if length(obj)<=32
+                        str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(32);');
+                        eval(str2eval)
+                    else
+                        str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(',num2str(length(roiName)),');');
+                        eval(str2eval)
+                    end
+                    options.d3.roi.colormap = c;
+                    for fi=1:length(roiName)
+                        pobj.color = options.d3.roi.colormap(fi,:);
+                        ea_roi([roiPath, roiName{fi}], pobj);
+                    end
+                elseif options.d3.roi.autofillcolor && length(roiName)==1
+                    for fi=1:length(roiName)
+                        pobj.color = ea_uisetcolor;
+                        ea_roi([roiPath, roiName{fi}], pobj);
+                    end
+                else
+                    for fi=1:length(roiName)
+                        pobj.color = ea_uisetcolor;
+                        ea_roi([roiPath, roiName{fi}], pobj);
+                    end
                 end
             end
+
         case 'tractmap'
             [tfina,tpana]=uigetfile('*.mat','Choose Fibertract to add to scene...',startPath,'MultiSelect','off');
             [rfina,rpana]=uigetfile({'*.nii';'*.nii.gz'},'Choose .nii image to colorcode tracts...',startPath,'MultiSelect','off');

--- a/ea_addobj.m
+++ b/ea_addobj.m
@@ -20,7 +20,7 @@ if iscell(obj) % dragndrop for tract and roi, 'obj' is a cell of the files
                 str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(32);');
                 eval(str2eval)
             else
-                str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(',num2str(length(roiName)),');');
+                str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(',num2str(length(obj)),');');
                 eval(str2eval)
             end
             options.d3.roi.colormap = c;

--- a/ea_addobj.m
+++ b/ea_addobj.m
@@ -1,7 +1,6 @@
 function ea_addobj(resultfig, obj, options)
 
 addht = getappdata(resultfig,'addht');
-prefs = ea_prefs;
 if isempty(addht)
     addht = uitoolbar(resultfig);
     setappdata(resultfig, 'addht', addht);
@@ -16,22 +15,16 @@ if iscell(obj) % dragndrop for tract and roi, 'obj' is a cell of the files
     elseif all(cellfun(@numel, regexp(obj, '(\.nii|\.nii\.gz)$', 'match', 'once'))) %roi
         pobj.plotFigureH = resultfig;
         pobj.htH = addht;
+        prefs = ea_prefs;
          if prefs.d3.roi.autofillcolor && length(obj)>1 % i.e. multiple roi's selected
             if length(obj)<=32
-                str2eval = strcat('c = ',prefs.d3.roi.defaultcolormap,'(32);');
-                eval(str2eval)
+                str2eval = ['cmap = ', prefs.d3.roi.defaultcolormap, '(32);'];
             else
-                str2eval = strcat('c = ',prefs.d3.roi.defaultcolormap,'(',num2str(length(obj)),');');
-                eval(str2eval)
+                str2eval = ['cmap = ', prefs.d3.roi.defaultcolormap, '(', num2str(length(obj)), ');'];
             end
-            prefs.d3.roi.colormap = c;
+            eval(str2eval);
             for i=1:length(obj)
-                pobj.color = prefs.d3.roi.colormap(i,:);
-                ea_roi(obj{i}, pobj);
-            end
-        elseif prefs.d3.roi.autofillcolor && length(obj)==1
-            for i=1:length(obj)
-                pobj.color = ea_uisetcolor;
+                pobj.color = cmap(i,:);
                 ea_roi(obj{i}, pobj);
             end
          else
@@ -40,13 +33,6 @@ if iscell(obj) % dragndrop for tract and roi, 'obj' is a cell of the files
                  ea_roi(obj{i}, pobj);
              end
          end
-
-
-
-        
-
-
-
     elseif all(cellfun(@numel, regexp(obj, '(\.fibfilt)$', 'match', 'once')))
         for i=1:length(obj)
             ea_discfiberexplorer(obj{i}, resultfig);
@@ -87,32 +73,26 @@ else  % uigetfile, 'obj' is the type of the files to be selected
         case 'roi' % atlas
             % open dialog
             [roiName, roiPath] = uigetfile({'*.nii';'*.nii.gz'},'Choose .nii image to add to scene...',startPath,'MultiSelect','on');
-            
+
             if isnumeric(roiName) % User pressed cancel, roiName is 0
                 return
             else
                 if ischar(roiName)
                     roiName = {roiName};
                 end
-                
+
                 pobj.plotFigureH = resultfig;
                 pobj.htH = addht;
+                prefs = ea_prefs;
                 if prefs.d3.roi.autofillcolor && length(roiName)>1 % i.e. multiple roi's selected
                     if length(obj)<=32
-                        str2eval = strcat('c = ',prefs.d3.roi.defaultcolormap,'(32);');
-                        eval(str2eval)
+                        str2eval = ['cmap = ', prefs.d3.roi.defaultcolormap, '(32);'];
                     else
-                        str2eval = strcat('c = ',prefs.d3.roi.defaultcolormap,'(',num2str(length(roiName)),');');
-                        eval(str2eval)
+                        str2eval = ['cmap = ', prefs.d3.roi.defaultcolormap, '(', num2str(length(roiName)), ');'];
                     end
-                    prefs.d3.roi.colormap = c;
+                    eval(str2eval);
                     for fi=1:length(roiName)
-                        pobj.color = prefs.d3.roi.colormap(fi,:);
-                        ea_roi([roiPath, roiName{fi}], pobj);
-                    end
-                elseif prefs.d3.roi.autofillcolor && length(roiName)==1
-                    for fi=1:length(roiName)
-                        pobj.color = ea_uisetcolor;
+                        pobj.color = cmap(fi,:);
                         ea_roi([roiPath, roiName{fi}], pobj);
                     end
                 else
@@ -122,7 +102,6 @@ else  % uigetfile, 'obj' is the type of the files to be selected
                     end
                 end
             end
-
         case 'tractmap'
             [tfina,tpana]=uigetfile('*.mat','Choose Fibertract to add to scene...',startPath,'MultiSelect','off');
             [rfina,rpana]=uigetfile({'*.nii';'*.nii.gz'},'Choose .nii image to colorcode tracts...',startPath,'MultiSelect','off');

--- a/ea_addobj.m
+++ b/ea_addobj.m
@@ -1,6 +1,7 @@
 function ea_addobj(resultfig, obj, options)
 
 addht = getappdata(resultfig,'addht');
+prefs = ea_prefs;
 if isempty(addht)
     addht = uitoolbar(resultfig);
     setappdata(resultfig, 'addht', addht);
@@ -15,20 +16,20 @@ if iscell(obj) % dragndrop for tract and roi, 'obj' is a cell of the files
     elseif all(cellfun(@numel, regexp(obj, '(\.nii|\.nii\.gz)$', 'match', 'once'))) %roi
         pobj.plotFigureH = resultfig;
         pobj.htH = addht;
-         if options.d3.roi.autofillcolor && length(obj)>1 % i.e. multiple roi's selected
+         if prefs.d3.roi.autofillcolor && length(obj)>1 % i.e. multiple roi's selected
             if length(obj)<=32
-                str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(32);');
+                str2eval = strcat('c = ',prefs.d3.roi.defaultcolormap,'(32);');
                 eval(str2eval)
             else
-                str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(',num2str(length(obj)),');');
+                str2eval = strcat('c = ',prefs.d3.roi.defaultcolormap,'(',num2str(length(obj)),');');
                 eval(str2eval)
             end
-            options.d3.roi.colormap = c;
+            prefs.d3.roi.colormap = c;
             for i=1:length(obj)
-                pobj.color = options.d3.roi.colormap(i,:);
+                pobj.color = prefs.d3.roi.colormap(i,:);
                 ea_roi(obj{i}, pobj);
             end
-        elseif options.d3.roi.autofillcolor && length(obj)==1
+        elseif prefs.d3.roi.autofillcolor && length(obj)==1
             for i=1:length(obj)
                 pobj.color = ea_uisetcolor;
                 ea_roi(obj{i}, pobj);
@@ -96,20 +97,20 @@ else  % uigetfile, 'obj' is the type of the files to be selected
                 
                 pobj.plotFigureH = resultfig;
                 pobj.htH = addht;
-                if options.d3.roi.autofillcolor && length(roiName)>1 % i.e. multiple roi's selected
+                if prefs.d3.roi.autofillcolor && length(roiName)>1 % i.e. multiple roi's selected
                     if length(obj)<=32
-                        str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(32);');
+                        str2eval = strcat('c = ',prefs.d3.roi.defaultcolormap,'(32);');
                         eval(str2eval)
                     else
-                        str2eval = strcat('c = ',options.d3.roi.defaultcolormap,'(',num2str(length(roiName)),');');
+                        str2eval = strcat('c = ',prefs.d3.roi.defaultcolormap,'(',num2str(length(roiName)),');');
                         eval(str2eval)
                     end
-                    options.d3.roi.colormap = c;
+                    prefs.d3.roi.colormap = c;
                     for fi=1:length(roiName)
-                        pobj.color = options.d3.roi.colormap(fi,:);
+                        pobj.color = prefs.d3.roi.colormap(fi,:);
                         ea_roi([roiPath, roiName{fi}], pobj);
                     end
-                elseif options.d3.roi.autofillcolor && length(roiName)==1
+                elseif prefs.d3.roi.autofillcolor && length(roiName)==1
                     for fi=1:length(roiName)
                         pobj.color = ea_uisetcolor;
                         ea_roi([roiPath, roiName{fi}], pobj);

--- a/ea_prefs.m
+++ b/ea_prefs.m
@@ -17,6 +17,12 @@ dmachine = load([ea_getearoot, 'common', filesep, 'ea_prefs_default.mat']);
 
 % check user prefs
 home = ea_gethome;
+try
+    eval(strcat(dprefs.d3.roi.defaultcolormap,';'))
+catch
+    error(strcat('Error in ea_prefs_default.m    prefs.d3.roi.defaultcolormap    ',prefs.d3.roi.defaultcolormap,'   is not a real colormap. See help graph3d for options.'))
+end
+
 
 % if isdeployed
 %     disp(['Running Lead-DBS in compiled mode, CTFROOT=', ea_getearoot, '; HOME=', home, '.']);

--- a/ea_prefs.m
+++ b/ea_prefs.m
@@ -17,12 +17,14 @@ dmachine = load([ea_getearoot, 'common', filesep, 'ea_prefs_default.mat']);
 
 % check user prefs
 home = ea_gethome;
-try
-    eval(strcat(dprefs.d3.roi.defaultcolormap,';'))
-catch
-    error(strcat('Error in ea_prefs_default.m    prefs.d3.roi.defaultcolormap    ',prefs.d3.roi.defaultcolormap,'   is not a real colormap. See help graph3d for options.'))
-end
 
+% Check default auto colormap setting
+try
+    eval([dprefs.d3.roi.defaultcolormap, ';'])
+catch
+    ea_cprintf('CmdWinWarnings', 'Default auto colormap was not set properly, fallback to ''turbo'' now.\n');
+    ea_setprefs('d3.roi.defaultcolormap', 'turbo', 'user');
+end
 
 % if isdeployed
 %     disp(['Running Lead-DBS in compiled mode, CTFROOT=', ea_getearoot, '; HOME=', home, '.']);

--- a/helpers/ea_mnifigure.m
+++ b/helpers/ea_mnifigure.m
@@ -16,6 +16,8 @@ ea_zoomcenter(resultfig.CurrentAxes, [0,0,0], 3);
 
 
 function options=getoptslocal
+prefs = ea_prefs; % load ea_prefs
+
 options.patientname='No Patient Selected';
 options.endtolerance = 10;
 options.sprungwert = 4;
@@ -70,6 +72,7 @@ options.d3.mirrorsides = 0;
 options.d3.autoserver = 0;
 options.d3.expdf = 0;
 options.d3.writeatlases = 1;
+options.d3.roi = prefs.d3.roi; % get roi options from ea_prefs
 options.numcontacts = 4;
 options.entrypoint = 'STN, GPi or ViM';
 options.entrypointn = 1;

--- a/helpers/ea_mnifigure.m
+++ b/helpers/ea_mnifigure.m
@@ -16,8 +16,6 @@ ea_zoomcenter(resultfig.CurrentAxes, [0,0,0], 3);
 
 
 function options=getoptslocal
-prefs = ea_prefs; % load ea_prefs
-
 options.patientname='No Patient Selected';
 options.endtolerance = 10;
 options.sprungwert = 4;
@@ -72,7 +70,6 @@ options.d3.mirrorsides = 0;
 options.d3.autoserver = 0;
 options.d3.expdf = 0;
 options.d3.writeatlases = 1;
-options.d3.roi = prefs.d3.roi; % get roi options from ea_prefs
 options.numcontacts = 4;
 options.entrypoint = 'STN, GPi or ViM';
 options.entrypointn = 1;

--- a/helpers/ea_setprefs.m
+++ b/helpers/ea_setprefs.m
@@ -23,7 +23,7 @@ switch lower(whichPrefs)
             error('Input value should be a string!');
         end
 
-        if isempty(str2num(value))
+        if isempty(str2num(value)) || ~isempty(regexp(value, '[a-zA-Z]+', 'once'))
             % value to be set is str
             value = ['''', value, ''''];
         end


### PR DESCRIPTION
I updated `ea_addobj.m` to autofill roi colors when adding more than one roi object to the resultfig scene. 

prefs.d3.roi.autofillcolor can be turned off in ea_prefs if preferred and it will still always ask for user input using `ea_uisetcolor`
prefs.d3.roi.colormap sets the default colormap to turbo

When adding only one ROI it will still always ask for color input from the use via `ea_uisetcolor`. This will work with drag and drop or choosing ROIs from the dropdown menu.  