### PR TITLE
BUG: use correct reference space h5toniigz

### DIFF
--- a/helpers/ea_legacy2bids.m
+++ b/helpers/ea_legacy2bids.m
@@ -753,23 +753,16 @@ function derivatives_cell = move_derivatives2bids(source_patient_path,new_path,w
             mkdir(transformations_dir)
         end
         old_path = fullfile(source_patient_path,which_file);
-        new_path = transformations_dir;
+        new_path = fullfile(transformations_dir,[patient_name,'_',bids_name]);
         if exist(old_path,'file')
-            %first move%
-            copyfile(old_path,new_path);
-            %then rename%
-            if endsWith(which_file,'.h5') %already renames
-                bids_name = [patient_name,'_',bids_name];
-                ea_h5toniigz(fullfile(new_path,which_file),fullfile(new_path,bids_name));
+            disp(['Renaming file ' which_file ' to ' bids_name]);
+            if endsWith(which_file,'.h5') 
+                ea_h5toniigz(old_path, new_path); % convert and rename
             else
-                disp(['Renaming file ' which_file ' to ' bids_name]);
-                rename_path = fullfile(new_path,which_file);
-                derivatives_cell{end+1,1} = fullfile(old_path);
-                derivatives_cell{end,2} = fullfile(new_path,[patient_name,'_',bids_name]);
-                movefile(rename_path,fullfile(new_path,[patient_name,'_',bids_name]));
+                copyfile(old_path, new_path); % copy and rename
             end
-            
-            
+            derivatives_cell{end+1,1} = fullfile(old_path);
+            derivatives_cell{end,2} = fullfile(new_path);
         end
     end
     

--- a/support_scripts/ea_h5toniigz.m
+++ b/support_scripts/ea_h5toniigz.m
@@ -1,4 +1,18 @@
-function ea_h5toniigz(h5file,output_file)
+function ea_h5toniigz(h5file,output_file,reference_file)
+
+
+if ~exist('reference_file','var') || isempty(reference_file)
+    if contains(output_file,'to-anchorNative')
+        anchorNative_files = dir(fullfile(fileparts(fileparts(fileparts(output_file))), 'coregistration', 'anat', '*space-anchorNative*.nii'));
+        if isempty(anchorNative_files)
+            error('No coregistered images found to use as reference')
+        end
+        reference_file = fullfile(anchorNative_files(1).folder, anchorNative_files(1).name)
+    else
+        reference_file = fullfile(ea_space,'t1.nii');
+    end
+end
+
 ea_libs_helper;
 basedir = [fullfile(ea_getearoot,'ext_libs','ANTs'), filesep];
 if ispc
@@ -6,11 +20,11 @@ if ispc
 else
     applyTransforms = ea_path_helper([basedir, 'antsApplyTransforms.', computer('arch')]);
 end
-mnifile = fullfile(ea_space,'t1.nii');
+
 %antsApplyTransforms -t glanatInverseComposite.h5 -r anat_t2.nii -o [glanatInverseComposite.nii.gz,1] --float -v 1
 cmd = [applyTransforms, ...
        ' -t ', h5file ...
-       ' -r ', mnifile ...
+       ' -r ', reference_file ...
        ' -o [', output_file ...
        ',1]' ...
        ' --float 1'...


### PR DESCRIPTION
reference file can be provided to function. if not its inferred from output transform name.

tested it on a couple of datasets