### PR TITLE
Spacedef file was renamed to space_def.mat

### DIFF
--- a/ea_compat_data.m
+++ b/ea_compat_data.m
@@ -22,9 +22,9 @@ if strcmp(ea_getspace,'MNI_ICBM_2009b_NLIN_ASYM')
         try movefile([space,'mni_wires.mat'],[space,'wires.mat']); end
     end
 
-    if ~exist([space,'space_def.mat'],'file')
+    if ~exist([space,'spacedef.mat'],'file')
         try spacedef=ea_gendefspacedef; end
-        try save([space,'space_def.mat'],'spacedef'); end
+        try save([space,'spacedef.mat'],'spacedef'); end
 
     end
 


### PR DESCRIPTION
Spacedef file was renamed to "space_def.mat" some time ago, however ea_compat_data.m creates "spacedef.mat" without "_"