### PR TITLE
Add SPM check that gives proper warning messages; make sure the banne…

### DIFF
--- a/ea_checkspm.m
+++ b/ea_checkspm.m
@@ -3,6 +3,7 @@ function ea_checkspm
 if ~isdeployed
     try
         ver=spm('version');
+        spm_check_installation('basic'); % have SPM check its path and binaries and give proper warnings and hints to the user if something is not good
     catch
         ea_error('SPM seems not installed. Please install SPM12 and add it to the Matlab path before using Lead-DBS.');
     end

--- a/ea_dispbn.m
+++ b/ea_dispbn.m
@@ -4,7 +4,6 @@ vnum=['v',ea_getvsn('local')];
 if nargin>0
     if strcmp(varargin{1},'ee')
         for space=1:100
-            clc
             spstr=repmat(' ',1,space);
             % display banner..
             disp('                 Welcome to                            ');
@@ -41,7 +40,6 @@ if nargin>0
     end
 else
     space=5;
-    clc
     spstr=repmat(' ',1,space);
     % display banner..
     disp('                 Welcome to                            ');


### PR DESCRIPTION
-Add SPM check that gives proper warning messages in case something is wrong by using `spm_check_installation`(problems with SPM seem frequently the case for example due to missing binary execute rights on Mac or path issues, for example when inuitivly being placed into "ext_libs" and subsequently lead dbs including all SPM subfolders to the path wrecking the whole Matlab installation by shadowing Matlab buildins :P);
-Make sure the leaddbs banner does not "clc away" **any** previous warning messages from the checks or other warnings/errors, leaving the poor user with a broken installation without any notice by clearing the previous command line outputs

Sidenote: Note that currently all sanity checks are run only from lead.m (e.g. when call ing `lead dbs`), i.e. when a user directly calls `lead_dbs` instead there are NO checks done at all. 