### PR TITLE
BUG migrate lead group

### DIFF
--- a/helpers/ea_migrateGroupAnalysis.m
+++ b/helpers/ea_migrateGroupAnalysis.m
@@ -20,6 +20,10 @@ try
     
     bids_name = ['dataset-' op_filename  '_analysis-' M.guid '.mat'];
 
+    if ~isfield(M.ui, 'mirrorsides')
+        M.ui.mirrorsides=0; 
+    end 
+
     for ii = 1:length(M.patient.list)
         
         [~, old_pname] = fileparts(M.patient.list{ii}); 


### PR DESCRIPTION
In older lead group files, M.ui.mirrorsides is absent and will cause errors after migrating the file.