### PR TITLE
Fix ea_keepatlaslabels and add ea_keeproilabels to toggle ROIs/Objects

### DIFF
--- a/helpers/scripts/ea_keepatlaslabels.m
+++ b/helpers/scripts/ea_keepatlaslabels.m
@@ -1,184 +1,50 @@
 function ea_keepatlaslabels(varargin)
 %
-% Helper function to keep atlas labels or turn them off
-%
+% Small function to keep atlas labels given string
 %
 % Example:
-%   Default to all objects/atlassurfs in scene
 %
 %   ea_keepatlaslabels('on');
-%   ea_keepatlaslabels('off');
+%   ea_keepatlaslabels('off')
 %
-% Example 2: include type of object either before or after 'on'/'off'
-%    type of object:
-%           1. atlas, atlasees, or atlassurfs
-%           2. object, objects, roi, rois
-%
-%   ea_keepatlaslabels('off','rois');
-%   ea_keepatlaslabels('off','atlases');
-%   ea_keepatlaslabels('rois','on');
-%   ea_keepatlaslabels('on','atlas');
+%   ea_keepatlaslabels('STN','RN','GPi','GPe')
+%   atlassurfs = ea_keepatlaslabels('STN','RN','GP')
+
 % _________________________________________________________________________
-% Copyright (C) 2023 Brigham and Women's Hospital
+% Copyright (C) 2017 University of Pittsburgh, Brain Modulation Lab
 %
 % Ari Kappel
 
-% Parse inputs
-% Default: Show all if no input parameters provided
-try
-    if isempty(varargin)
-        toggle = 'on';
-        type = 'all';
-    elseif nargin==1
-        toggle = lower(varargin{1});
-        type = 'all'; % default to all
-    elseif nargin==2
-        if any(strcmpi(varargin{1},{'on','off'}))
-            toggle = lower(varargin{1});
-            type = lower(varargin{2});
-        elseif any(strcmpi(varargin{2},{'on','off'}))
-            type = lower(varargin{1});
-            toggle = lower(varargin{2});
-        end
+H = findall(0,'type','figure');
+resultfig = H(contains({H(:).Name},{'Electrode-Scene'}));
+resultfig=resultfig(1); % Take the first if there are more.
+set(0,'CurrentFigure',resultfig)
+
+atlassurfs = getappdata(resultfig,'atlassurfs');
+colorbuttons = getappdata(resultfig,'colorbuttons');
+
+% Show all atlases in case no input parameter
+if isempty(varargin)
+    atlasToggle = {'on'};
+else
+    atlasToggle = lower(varargin);
+end
+
+idx = [];
+for i = 1:length(atlassurfs)
+    atlasTag = lower(atlassurfs{i}.Tag);
+    atlasName = regexprep(atlasTag, '_(left|right|midline|mixed)$', '');
+    if strcmp(atlasToggle{1}, 'on') ... % Turn on all atlases
+            || ismember(atlasTag, atlasToggle) ... % Match exactly
+            || ismember(atlasName, atlasToggle) % Match name regardless of side
+        idx = [idx, i];
+        atlassurfs{i}.Visible = 'on';
+        colorbuttons(i).State = 'on';
     else
-        toggle = 'on';
-        type='all';
+        atlassurfs{i}.Visible = 'off';
+        colorbuttons(i).State = 'off';
     end
+end
 
-    % get figure handles
-    % Warning: may not work with mutliple scenes open
-    H = findall(0,'type','figure');
-    resultfig = H(contains({H(:).Name},{'Electrode-Scene'}));
-    resultfig=resultfig(1); % Take the first if there are more.
-    set(0,'CurrentFigure',resultfig);
-
-    % get app data
-    atlassurfs = getappdata(resultfig,'atlassurfs');
-    colorbuttons = getappdata(resultfig,'colorbuttons');
-
-    addht = getappdata(resultfig,'addht');
-    rois = findobj(addht.Children, 'Type', 'uitoggletool', 'UserData', 'roi');
-
-    % parse type and toggle
-    switch type
-        case 'all'
-            switch toggle
-                case 'on'
-                    % atlassurfs
-                    idx = [];
-                    for i = 1:length(atlassurfs)
-                        atlasTag = lower(atlassurfs{i}.Tag);
-                        atlasName = regexprep(atlasTag, '_(left|right|midline|mixed)$', '');
-                        if strcmp(toggle, 'on') ... % Turn on all atlases
-                                || ismember(atlasTag, toggle) ... % Match exactly
-                                || ismember(atlasName, toggle) % Match name regardless of side
-                            idx = [idx, i];
-                            atlassurfs{i}.Visible = 'on';
-                            colorbuttons(i).State = 'on';
-                        end
-                    end
-                    atlassurfs = atlassurfs(idx);
-                    % rois
-                    for i = 1:length(rois)
-                        rois(i).State='on';
-                    end
-                case 'off'
-                    % atlassurfs
-                    for i = 1:length(atlassurfs)
-                        atlassurfs{i}.Visible = 'off';
-                        colorbuttons(i).State = 'off';
-                    end
-                    % rois
-                    for i = 1:length(rois)
-                        rois(i).State='off';
-                    end
-            end
-
-        case {'atlas','atlases','atlassurfs'}
-            switch toggle
-                case 'on'
-                    % turn atlassurfs on
-                    idx = [];
-                    for i = 1:length(atlassurfs)
-                        atlasTag = lower(atlassurfs{i}.Tag);
-                        atlasName = regexprep(atlasTag, '_(left|right|midline|mixed)$', '');
-                        if strcmp(toggle, 'on') ... % Turn on all atlases
-                                || ismember(atlasTag, toggle) ... % Match exactly
-                                || ismember(atlasName, toggle) % Match name regardless of side
-                            idx = [idx, i];
-                            atlassurfs{i}.Visible = 'on';
-                            colorbuttons(i).State = 'on';
-                        end
-                    end
-                    atlassurfs = atlassurfs(idx);
-                    % turn atlassurfs off
-                case 'off'
-                    for i = 1:length(atlassurfs)
-                        atlassurfs{i}.Visible = 'off';
-                        colorbuttons(i).State = 'off';
-                    end
-            end
-
-        case {'object','objects','roi','rois'}
-            switch toggle
-                case 'on'
-                    for i = 1:length(rois)
-                        rois(i).State='on';
-                    end
-                case 'off'
-                    for i = 1:length(rois)
-                        rois(i).State='off';
-                    end
-            end
-    end
-catch
-    % LEGACY
-    %
-    % Small function to keep atlas labels given string
-    %
-    % Example:
-    %
-    %   ea_keepatlaslabels('on');
-    %   ea_keepatlaslabels('off')
-    %
-    %   ea_keepatlaslabels('STN','RN','GPi','GPe')
-    %   atlassurfs = ea_keepatlaslabels('STN','RN','GP')
-    
-    % _________________________________________________________________________
-    % Copyright (C) 2017 University of Pittsburgh, Brain Modulation Lab
-    %
-    % Ari Kappel
-
-    H = findall(0,'type','figure');
-    resultfig = H(contains({H(:).Name},{'Electrode-Scene'}));
-    resultfig=resultfig(1); % Take the first if there are more.
-    set(0,'CurrentFigure',resultfig)
-
-    atlassurfs = getappdata(resultfig,'atlassurfs');
-    colorbuttons = getappdata(resultfig,'colorbuttons');
-
-    % Show all atlases in case no input parameter
-    if isempty(varargin)
-        atlasToggle = {'on'};
-    else
-        atlasToggle = lower(varargin);
-    end
-
-    idx = [];
-    for i = 1:length(atlassurfs)
-        atlasTag = lower(atlassurfs{i}.Tag);
-        atlasName = regexprep(atlasTag, '_(left|right|midline|mixed)$', '');
-        if strcmp(atlasToggle{1}, 'on') ... % Turn on all atlases
-                || ismember(atlasTag, atlasToggle) ... % Match exactly
-                || ismember(atlasName, atlasToggle) % Match name regardless of side
-            idx = [idx, i];
-            atlassurfs{i}.Visible = 'on';
-            colorbuttons(i).State = 'on';
-        else
-            atlassurfs{i}.Visible = 'off';
-            colorbuttons(i).State = 'off';
-        end
-    end
-
-    atlassurfs = atlassurfs(idx);
+atlassurfs = atlassurfs(idx);
 end

--- a/helpers/scripts/ea_keeproilabels.m
+++ b/helpers/scripts/ea_keeproilabels.m
@@ -6,18 +6,23 @@ function ea_keeproilabels(varargin)
 % Example:
 %   Default to all objects/atlassurfs in scene
 %
-%   ea_keepatlaslabels('on');
-%   ea_keepatlaslabels('off');
+%   ea_keeproilabels('on'); 
+%   ea_keeproilabels('off');
+%
+%   Note: this syntax has a similar function to ea_keepatlaslabels 
+%       and will toggle all objects/atlassurfs in scene on/off.
+%       Use ea_keepatlaslabels to toggle type of atlas labels on/off 
+%       e.g. ea_keepatlaslabels('STN')
 %
 % Example 2: include type of object either before or after 'on'/'off'
 %    type of object:
 %           1. atlas, atlasees, or atlassurfs
 %           2. object, objects, roi, rois
 %
-%   ea_keepatlaslabels('off','rois');
-%   ea_keepatlaslabels('off','atlases');
-%   ea_keepatlaslabels('rois','on');
-%   ea_keepatlaslabels('on','atlas');
+%   ea_keeproilabels('off','rois');
+%   ea_keeproilabels('off','atlases');
+%   ea_keeproilabels('rois','on');
+%   ea_keeproilabels('on','atlas');
 % _________________________________________________________________________
 % Copyright (C) 2023 Brigham and Women's Hospital
 %
@@ -25,110 +30,108 @@ function ea_keeproilabels(varargin)
 
 % Parse inputs
 % Default: Show all if no input parameters provided
-try
-    if isempty(varargin)
-        toggle = 'on';
-        type = 'all';
-    elseif nargin==1
+if isempty(varargin)
+    toggle = 'on';
+    type = 'all';
+elseif nargin==1
+    toggle = lower(varargin{1});
+    type = 'all'; % default to all
+elseif nargin==2
+    if any(strcmpi(varargin{1},{'on','off'}))
         toggle = lower(varargin{1});
-        type = 'all'; % default to all
-    elseif nargin==2
-        if any(strcmpi(varargin{1},{'on','off'}))
-            toggle = lower(varargin{1});
-            type = lower(varargin{2});
-        elseif any(strcmpi(varargin{2},{'on','off'}))
-            type = lower(varargin{1});
-            toggle = lower(varargin{2});
+        type = lower(varargin{2});
+    elseif any(strcmpi(varargin{2},{'on','off'}))
+        type = lower(varargin{1});
+        toggle = lower(varargin{2});
+    end
+else
+    toggle = 'on';
+    type='all';
+end
+
+% get figure handles
+% Warning: may not work with mutliple scenes open
+H = findall(0,'type','figure');
+resultfig = H(contains({H(:).Name},{'Electrode-Scene'}));
+resultfig=resultfig(1); % Take the first if there are more.
+set(0,'CurrentFigure',resultfig);
+
+% get app data
+atlassurfs = getappdata(resultfig,'atlassurfs');
+colorbuttons = getappdata(resultfig,'colorbuttons');
+
+addht = getappdata(resultfig,'addht');
+rois = findobj(addht.Children, 'Type', 'uitoggletool', 'UserData', 'roi');
+
+% parse type and toggle
+switch type
+    case 'all'
+        switch toggle
+            case 'on'
+                % atlassurfs
+                idx = [];
+                for i = 1:length(atlassurfs)
+                    atlasTag = lower(atlassurfs{i}.Tag);
+                    atlasName = regexprep(atlasTag, '_(left|right|midline|mixed)$', '');
+                    if strcmp(toggle, 'on') ... % Turn on all atlases
+                            || ismember(atlasTag, toggle) ... % Match exactly
+                            || ismember(atlasName, toggle) % Match name regardless of side
+                        idx = [idx, i];
+                        atlassurfs{i}.Visible = 'on';
+                        colorbuttons(i).State = 'on';
+                    end
+                end
+                atlassurfs = atlassurfs(idx);
+                % rois
+                for i = 1:length(rois)
+                    rois(i).State='on';
+                end
+            case 'off'
+                % atlassurfs
+                for i = 1:length(atlassurfs)
+                    atlassurfs{i}.Visible = 'off';
+                    colorbuttons(i).State = 'off';
+                end
+                % rois
+                for i = 1:length(rois)
+                    rois(i).State='off';
+                end
         end
-    else
-        toggle = 'on';
-        type='all';
-    end
 
-    % get figure handles
-    % Warning: may not work with mutliple scenes open
-    H = findall(0,'type','figure');
-    resultfig = H(contains({H(:).Name},{'Electrode-Scene'}));
-    resultfig=resultfig(1); % Take the first if there are more.
-    set(0,'CurrentFigure',resultfig);
+    case {'atlas','atlases','atlassurfs'}
+        switch toggle
+            case 'on'
+                % turn atlassurfs on
+                idx = [];
+                for i = 1:length(atlassurfs)
+                    atlasTag = lower(atlassurfs{i}.Tag);
+                    atlasName = regexprep(atlasTag, '_(left|right|midline|mixed)$', '');
+                    if strcmp(toggle, 'on') ... % Turn on all atlases
+                            || ismember(atlasTag, toggle) ... % Match exactly
+                            || ismember(atlasName, toggle) % Match name regardless of side
+                        idx = [idx, i];
+                        atlassurfs{i}.Visible = 'on';
+                        colorbuttons(i).State = 'on';
+                    end
+                end
+                atlassurfs = atlassurfs(idx);
+                % turn atlassurfs off
+            case 'off'
+                for i = 1:length(atlassurfs)
+                    atlassurfs{i}.Visible = 'off';
+                    colorbuttons(i).State = 'off';
+                end
+        end
 
-    % get app data
-    atlassurfs = getappdata(resultfig,'atlassurfs');
-    colorbuttons = getappdata(resultfig,'colorbuttons');
-
-    addht = getappdata(resultfig,'addht');
-    rois = findobj(addht.Children, 'Type', 'uitoggletool', 'UserData', 'roi');
-
-    % parse type and toggle
-    switch type
-        case 'all'
-            switch toggle
-                case 'on'
-                    % atlassurfs
-                    idx = [];
-                    for i = 1:length(atlassurfs)
-                        atlasTag = lower(atlassurfs{i}.Tag);
-                        atlasName = regexprep(atlasTag, '_(left|right|midline|mixed)$', '');
-                        if strcmp(toggle, 'on') ... % Turn on all atlases
-                                || ismember(atlasTag, toggle) ... % Match exactly
-                                || ismember(atlasName, toggle) % Match name regardless of side
-                            idx = [idx, i];
-                            atlassurfs{i}.Visible = 'on';
-                            colorbuttons(i).State = 'on';
-                        end
-                    end
-                    atlassurfs = atlassurfs(idx);
-                    % rois
-                    for i = 1:length(rois)
-                        rois(i).State='on';
-                    end
-                case 'off'
-                    % atlassurfs
-                    for i = 1:length(atlassurfs)
-                        atlassurfs{i}.Visible = 'off';
-                        colorbuttons(i).State = 'off';
-                    end
-                    % rois
-                    for i = 1:length(rois)
-                        rois(i).State='off';
-                    end
-            end
-
-        case {'atlas','atlases','atlassurfs'}
-            switch toggle
-                case 'on'
-                    % turn atlassurfs on
-                    idx = [];
-                    for i = 1:length(atlassurfs)
-                        atlasTag = lower(atlassurfs{i}.Tag);
-                        atlasName = regexprep(atlasTag, '_(left|right|midline|mixed)$', '');
-                        if strcmp(toggle, 'on') ... % Turn on all atlases
-                                || ismember(atlasTag, toggle) ... % Match exactly
-                                || ismember(atlasName, toggle) % Match name regardless of side
-                            idx = [idx, i];
-                            atlassurfs{i}.Visible = 'on';
-                            colorbuttons(i).State = 'on';
-                        end
-                    end
-                    atlassurfs = atlassurfs(idx);
-                    % turn atlassurfs off
-                case 'off'
-                    for i = 1:length(atlassurfs)
-                        atlassurfs{i}.Visible = 'off';
-                        colorbuttons(i).State = 'off';
-                    end
-            end
-
-        case {'object','objects','roi','rois'}
-            switch toggle
-                case 'on'
-                    for i = 1:length(rois)
-                        rois(i).State='on';
-                    end
-                case 'off'
-                    for i = 1:length(rois)
-                        rois(i).State='off';
-                    end
-            end
-    end
-catch
+    case {'object','objects','roi','rois'}
+        switch toggle
+            case 'on'
+                for i = 1:length(rois)
+                    rois(i).State='on';
+                end
+            case 'off'
+                for i = 1:length(rois)
+                    rois(i).State='off';
+                end
+        end
+end

--- a/helpers/scripts/ea_keeproilabels.m
+++ b/helpers/scripts/ea_keeproilabels.m
@@ -1,0 +1,134 @@
+function ea_keeproilabels(varargin)
+%
+% Helper function to keep roi labels or turn them off
+%
+%
+% Example:
+%   Default to all objects/atlassurfs in scene
+%
+%   ea_keepatlaslabels('on');
+%   ea_keepatlaslabels('off');
+%
+% Example 2: include type of object either before or after 'on'/'off'
+%    type of object:
+%           1. atlas, atlasees, or atlassurfs
+%           2. object, objects, roi, rois
+%
+%   ea_keepatlaslabels('off','rois');
+%   ea_keepatlaslabels('off','atlases');
+%   ea_keepatlaslabels('rois','on');
+%   ea_keepatlaslabels('on','atlas');
+% _________________________________________________________________________
+% Copyright (C) 2023 Brigham and Women's Hospital
+%
+% Ari Kappel
+
+% Parse inputs
+% Default: Show all if no input parameters provided
+try
+    if isempty(varargin)
+        toggle = 'on';
+        type = 'all';
+    elseif nargin==1
+        toggle = lower(varargin{1});
+        type = 'all'; % default to all
+    elseif nargin==2
+        if any(strcmpi(varargin{1},{'on','off'}))
+            toggle = lower(varargin{1});
+            type = lower(varargin{2});
+        elseif any(strcmpi(varargin{2},{'on','off'}))
+            type = lower(varargin{1});
+            toggle = lower(varargin{2});
+        end
+    else
+        toggle = 'on';
+        type='all';
+    end
+
+    % get figure handles
+    % Warning: may not work with mutliple scenes open
+    H = findall(0,'type','figure');
+    resultfig = H(contains({H(:).Name},{'Electrode-Scene'}));
+    resultfig=resultfig(1); % Take the first if there are more.
+    set(0,'CurrentFigure',resultfig);
+
+    % get app data
+    atlassurfs = getappdata(resultfig,'atlassurfs');
+    colorbuttons = getappdata(resultfig,'colorbuttons');
+
+    addht = getappdata(resultfig,'addht');
+    rois = findobj(addht.Children, 'Type', 'uitoggletool', 'UserData', 'roi');
+
+    % parse type and toggle
+    switch type
+        case 'all'
+            switch toggle
+                case 'on'
+                    % atlassurfs
+                    idx = [];
+                    for i = 1:length(atlassurfs)
+                        atlasTag = lower(atlassurfs{i}.Tag);
+                        atlasName = regexprep(atlasTag, '_(left|right|midline|mixed)$', '');
+                        if strcmp(toggle, 'on') ... % Turn on all atlases
+                                || ismember(atlasTag, toggle) ... % Match exactly
+                                || ismember(atlasName, toggle) % Match name regardless of side
+                            idx = [idx, i];
+                            atlassurfs{i}.Visible = 'on';
+                            colorbuttons(i).State = 'on';
+                        end
+                    end
+                    atlassurfs = atlassurfs(idx);
+                    % rois
+                    for i = 1:length(rois)
+                        rois(i).State='on';
+                    end
+                case 'off'
+                    % atlassurfs
+                    for i = 1:length(atlassurfs)
+                        atlassurfs{i}.Visible = 'off';
+                        colorbuttons(i).State = 'off';
+                    end
+                    % rois
+                    for i = 1:length(rois)
+                        rois(i).State='off';
+                    end
+            end
+
+        case {'atlas','atlases','atlassurfs'}
+            switch toggle
+                case 'on'
+                    % turn atlassurfs on
+                    idx = [];
+                    for i = 1:length(atlassurfs)
+                        atlasTag = lower(atlassurfs{i}.Tag);
+                        atlasName = regexprep(atlasTag, '_(left|right|midline|mixed)$', '');
+                        if strcmp(toggle, 'on') ... % Turn on all atlases
+                                || ismember(atlasTag, toggle) ... % Match exactly
+                                || ismember(atlasName, toggle) % Match name regardless of side
+                            idx = [idx, i];
+                            atlassurfs{i}.Visible = 'on';
+                            colorbuttons(i).State = 'on';
+                        end
+                    end
+                    atlassurfs = atlassurfs(idx);
+                    % turn atlassurfs off
+                case 'off'
+                    for i = 1:length(atlassurfs)
+                        atlassurfs{i}.Visible = 'off';
+                        colorbuttons(i).State = 'off';
+                    end
+            end
+
+        case {'object','objects','roi','rois'}
+            switch toggle
+                case 'on'
+                    for i = 1:length(rois)
+                        rois(i).State='on';
+                    end
+                case 'off'
+                    for i = 1:length(rois)
+                        rois(i).State='off';
+                    end
+            end
+    end
+catch


### PR DESCRIPTION
Returns ea_keepatlaslabels to legacy version and adds ea_keeproilabels to allow easy toggling of roi labels on/off