### PR TITLE
ENH: Add check for potential MacOSFileQuarantine of SPM executables

### DIFF
--- a/ea_checkspm.m
+++ b/ea_checkspm.m
@@ -4,6 +4,14 @@ if ~isdeployed
     try
         ver=spm('version');
         spm_check_installation('basic'); % have SPM check its path and binaries and give proper warnings and hints to the user if something is not good
+        
+        % Get the SPM folder path 
+        SPMDir = cellstr(which('spm.m','-ALL'));
+        SPMDir = fileparts(SPMDir{1});
+        
+        % check for spm binary executables that are not executable due to
+        % macOS file quarantine
+        checkMacOSFileQuarantine(SPMDir)
     catch
         ea_error('SPM seems not installed. Please install SPM12 and add it to the Matlab path before using Lead-DBS.');
     end

--- a/ea_checkspm.m
+++ b/ea_checkspm.m
@@ -11,7 +11,9 @@ if ~isdeployed
         
         % check for spm binary executables that are not executable due to
         % macOS file quarantine
-        checkMacOSFileQuarantine(SPMDir)
+        if(ismac)
+           checkMacOSFileQuarantine(SPMDir)
+        end
     catch
         ea_error('SPM seems not installed. Please install SPM12 and add it to the Matlab path before using Lead-DBS.');
     end

--- a/ext_libs/checkMacOSFileQuarantine.m
+++ b/ext_libs/checkMacOSFileQuarantine.m
@@ -1,0 +1,34 @@
+% Mac OSX "quaranteens" downloaded executable files and prevents them from
+% beeing executed for IT security reseasons. The user has to explicit remove
+% the quranteen once, which is normally done by an explicit "right-click" and
+% "open" user action. 
+%
+% This function checks if any executable files in the given folderpath are
+% quranteend and thus cannot be executed preventing software reling on them
+% from funtioning properly. 
+%
+% If quranteened files are found, a warning is raised an a solution command
+% to lift the file qurantine is suggested to the user.
+%
+% Andreas Husch, andreas.husch@uni.lu
+% University of Luxembourg, LCSB, Imaging AI Group, 2023
+
+function checkMacOSFileQuarantine(folderpath, filepattern)
+    if(nargin < 2)
+        filepattern = '*.mexmaci64';
+    end
+
+    [~, xattrs] = system(['xattr ' folderpath filesep filepattern]);
+
+    % check for files that are in status 'com.apple.quarantine'
+    xattrsCell = split(xattrs, newline);
+    quarantinedStr = strfind(xattrsCell, 'com.apple.quarantine');
+    qurantinedIdxs = cellfun(@(cell)(~isempty(cell)), quarantinedStr);
+
+    if(any(qurantinedIdxs))
+        warning(['Found executable ' filepattern ' files in folder ' folderpath ' that are under Mac OSX file quarantine and thus cannot be executed: ' newline newline ...
+            xattrsCell{qurantinedIdxs} newline newline...
+            'lift the qurantine by "right-click" and "open" each file once or by running terminal command' newline ...
+            '"sudo xattr -r -d com.apple.quarantine ' folderpath filesep filepattern '"'] )
+    end
+end


### PR DESCRIPTION
On the hunt for fresh install bugs and obstacles to lay users, I would like to suggest adding a check for MacOS file quarantine of SPM executables, as this effectively blocks SPM from working after a fresh download. 

This might apply also for other (non-SPM) binaries, thus I wrote a general check function that could also be used for checking other binaries later.


### Background:
Mac OSX "quaranteens" downloaded executable files and prevents them from
beeing executed for IT security reseasons. The user has to explicit remove
the quranteen once, which is normally done by an explicit "right-click" and
 "open" user action. 

`checkMacOSFileQurantine.m` checks if any executable files in the given folderpath are
quranteend and thus cannot be executed preventing software reling on them
from funtioning properly. 

If quranteened files are found, a warning is raised an a solution command
to lift the file qurantine is suggested to the user.


### Status of integration:
A check for the SPM is added to `ea_checkspm.m` in this PR. 

