### PR TITLE
FIX minor bugs fiberfiltering

### DIFF
--- a/connectomics/discfibers/ea_disctract.m
+++ b/connectomics/discfibers/ea_disctract.m
@@ -650,20 +650,22 @@ classdef ea_disctract < handle
 
             end
 
-            % check if binary variable
-            if all(ismember(Improvement(:,1), [0,1])) && size(val_struct{c}.vals,1) == 1
-                % average across sides. This might be wrong for capsular response.
-                Ihat_av_sides = ea_nanmean(Ihat,2);
+            if ~iscell(Improvement) % skip for multitract modes 
+                % check if binary variable
+                if all(ismember(Improvement(:,1), [0,1])) && size(val_struct{c}.vals,1) == 1
+                    % average across sides. This might be wrong for capsular response.
+                    Ihat_av_sides = ea_nanmean(Ihat,2);
 
-                if isobject(cvp)
-                    % In-sample
-                    AUC = ea_logit_regression(0 ,Ihat_av_sides, Improvement, 1:size(Improvement,1), 1:size(Improvement,1));
-                elseif isstruct(cvp)
-                    % actual training and test
-                    Ihat_train_global_av_sides = ea_nanmean(Ihat_train_global,3); % in this case, dimens is (1, N, sides)
-                    AUC = ea_logit_regression(Ihat_train_global_av_sides(training)', Ihat_av_sides, Improvement, training, test);
+                    if isobject(cvp)
+                        % In-sample
+                        AUC = ea_logit_regression(0 ,Ihat_av_sides, Improvement, 1:size(Improvement,1), 1:size(Improvement,1));
+                    elseif isstruct(cvp)
+                        % actual training and test
+                        Ihat_train_global_av_sides = ea_nanmean(Ihat_train_global,3); % in this case, dimens is (1, N, sides)
+                        AUC = ea_logit_regression(Ihat_train_global_av_sides(training)', Ihat_av_sides, Improvement, training, test);
+                    end
+
                 end
-
             end
 
             if ~silent

--- a/connectomics/discfibers/ea_disctract_crossval.m
+++ b/connectomics/discfibers/ea_disctract_crossval.m
@@ -43,6 +43,10 @@ switch strategy
         tractset.nestedLOO = false;
         tractset.useExternalModel = false;
         tractset.customselection = [];
+
+        if ~isfield(customconfig, 'permcorrtype')
+            customconfig.permcorrtype = 'Spearman';
+        end
         [I,Ihat,R0,R1,pperm,~,val_struct]=tractset.lnopb(customconfig.permcorrtype,silent);
         if ~silent
             if strcmp(tractset.multitractmode,'Split & Color By PCA')


### PR DESCRIPTION
Issue with pca/multitract mode + Issue with permutations

The fix for the issue with permutations follows from existing code, it seems that CorrType was never explicitly declared. In ea_disctract: 

```
function [Iperm, Ihat, R0, R1, pperm, Rp95, val_struct] = lnopb(obj, corrType, silent)
    if ~exist('corrType', 'var')
        corrType = 'Spearman';
    end
```
