### PR TITLE
Update ea_conda.m

### DIFF
--- a/classes/conda_utils/ea_conda.m
+++ b/classes/conda_utils/ea_conda.m
@@ -43,7 +43,7 @@ classdef (Abstract) ea_conda
             end
 
             mambaforge_installer_url =  ['https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-' osarch];
-            installer_file = fullfile(ea_conda.install_path, 'mambaforge');
+            installer_file = fullfile(ea_getearoot, 'mambaforge');
 
             if isunix
                 mambaforge_installer_url = [mambaforge_installer_url '.sh'];


### PR DESCRIPTION
Fix: Error in OSS-DBS install for Windows where mambaforge cannot be installed to the same folder as where the installer is located
@ningfei: This fixes an error when installing OSS-DBS on windows. The installer apparently cannot be in the target folder. This just moves the installer to ea_getearoot. Since the installer is deleted at the end anyway I think it should not make any difference for Mac and Linux