### PR TITLE
ENH better dealing with subthreshold values.

### DIFF
--- a/classes/sweetspotmapping/ea_sweetspot_calcstats.m
+++ b/classes/sweetspotmapping/ea_sweetspot_calcstats.m
@@ -71,7 +71,8 @@ for group=groups
             case 'VTAs'
                 gval{side}=gval{side}>obj.efieldthreshold; % binarize
             case 'E-Fields'
-                gval{side}(gval{side}<obj.efieldthreshold)=nan; % threshold efields
+                Nmap=ea_nansum(gval{side}>obj.efieldthreshold);
+                gval{side}(:,Nmap<round(size(gval{side},1)*(obj.coverthreshold/100)))=nan; % Set pixels to Nan that do not meet coverthreshold criteria
         end
         switch obj.statlevel
             case 'VTAs'

--- a/connectomics/discfibers/ea_discfibers_calcstats.m
+++ b/connectomics/discfibers/ea_discfibers_calcstats.m
@@ -185,11 +185,11 @@ for group=groups
         % remove fibers that are not connected to enough VTAs/Efields or connected
         % to too many VTAs (connthreshold slider)
         if ~obj.runwhite
-            gfibsval{side}(sumgfibsval<((obj.connthreshold/100)*length(gpatsel)),gpatsel)=0;
+            gfibsval{side}(sumgfibsval<((obj.connthreshold/100)*length(gpatsel)),gpatsel)=nan;
             if ~(ismember(obj.statmetric,{'Correlations / E-fields (Irmen 2020)','Reverse T-Tests / E-Fields (binary vars)'})) % efields & reverse t-tests for binary vars cases
                 % only in case of VTAs (given two-sample-t-test statistic) do we
                 % need to also exclude if tract is connected to too many VTAs:
-                gfibsval{side}(sumgfibsval>((1-(obj.connthreshold/100))*length(gpatsel)),gpatsel)=0;
+                gfibsval{side}(sumgfibsval>((1-(obj.connthreshold/100))*length(gpatsel)),gpatsel)=nan;
             end
         end
         


### PR DESCRIPTION
This PR adds changes that could affect results in ongoing analyses.
While no real bugs before, dealing subthreshold Efield values had been misleading before.

Sweetspot explorer:
Before this change:
For each E-field, values below the efieldthreshold were set to nan for each individual E-field.

After this change:
Values of pixels that do not meet criteria (coverthreshold & efieldthreshold) are set to Nan.

-> This better reflects what is suggested to happen by the GUI and may add power to some pixels.


Fibefiltering explorer:
Before this change:
Fibervalues that did not meet criteria of being "connected" to specific efields (connthreshold) were set to 0. In posthoc stats, this may have led to these fibers not excluded but these could still be part of e.g. the Spearman correlation.

After this change:
Instead of setting to zero, values will be set to nan, leading to them being ignored entirely.

-> This better reflects what is suggested to happen by the GUI and leads to proper exclusion of fibers that do not meet criteria.