### PR TITLE
ENH also look for 'mixed' tracts in atlas2conn

### DIFF
--- a/helpers/ea_atlas2conn.m
+++ b/helpers/ea_atlas2conn.m
@@ -11,6 +11,10 @@ rightTracts = ea_regexpdir([atlasFolder, filesep, 'rh'], '^(?!\.).*\.mat$', 1);
 [~, rightTractNames] = cellfun(@fileparts, rightTracts, 'Uni', 0);
 rightTractNames = strcat({'Right '}, rightTractNames);
 
+% Retrieve "mixed" tracts, if they exist, eg commissural tracts
+mixedTracts = ea_regexpdir([atlasFolder, filesep, 'mixed'], '^(?!\.).*\.mat$', 1);
+[~, mixedTractNames] = cellfun(@fileparts, mixedTracts, 'Uni', 0); % no need to add a prefix here
+
 % Create connectome folder if necessary
 connectomeFolder = [ea_getconnectomebase('dMRI'), connectomeName];
 if ~isfolder(connectomeFolder)
@@ -18,8 +22,8 @@ if ~isfolder(connectomeFolder)
 end
 
 % Aggregate fiber tracts tp create a normal dMRI connectome
-[~, ~, partition] = ea_ftr_aggregate([leftTracts; rightTracts], [connectomeFolder, filesep, 'data.mat']);
+[~, ~, partition] = ea_ftr_aggregate([leftTracts; rightTracts; mixedTracts], [connectomeFolder, filesep, 'data.mat']);
 
 % Save pathway names
-pathway = repelem([leftTractNames; rightTractNames], partition);
+pathway = repelem([leftTractNames; rightTractNames; mixedTractNames], partition);
 save([connectomeFolder, filesep, 'pathway.mat'], 'pathway');


### PR DESCRIPTION
Allows to retrieve mixed tracts, since commissural tracts should be stored in the mixed folder
@nrajamani3 