### PR TITLE
FIX: Lead-Connectome B0→anat transform for BIDS intermediate filenames

### DIFF
--- a/connectomics/ea_ensure_b0_coreg.m
+++ b/connectomics/ea_ensure_b0_coreg.m
@@ -3,7 +3,9 @@ function options = ea_ensure_b0_coreg(options)
 % 
 % This helper is intended to be called from the main pipeline (ea_autocoord)
 % before any Lead-Connectome structural steps run. It is read-only with
-% respect to options except for potential updates to options.coregmr.method.
+% respect to options except for potential updates to options.coregmr.method
+% and an in-memory LC-only correction of options.prefs.prenii_unnormalized
+% via ea_lc_resolve_anat_anchor.
 %
 % Behaviour:
 %   1. If a B0 image or preprocessed T1 cannot be found, the function
@@ -28,46 +30,45 @@ if ~isfile(b0Path)
     b0Path = fullfile(d(1).folder, d(1).name);
 end
 
-% Locate preprocessed T1
-anatDir = fullfile(directory, 'preprocessing', 'anat');
-if ~isfolder(anatDir)
-    fprintf('ea_ensure_b0_coreg: preprocessing/anat directory not found, skipping.\n');
+% Locate anatomical anchor (LC-only resolver; ignores SPM/coreg intermediates)
+[options, anatRel, anatName] = ea_lc_resolve_anat_anchor(options);
+if isempty(anatRel)
+    fprintf('ea_ensure_b0_coreg: No valid anatomical anchor found, skipping.\n');
     return;
 end
-cand = dir(fullfile(anatDir, '*desc-preproc*_T1w.nii'));
-if isempty(cand)
-    cand = dir(fullfile(anatDir, '*acq-iso_T1w.nii'));
-end
-if isempty(cand)
-    cand = dir(fullfile(anatDir, '*T1w.nii'));
-end
-if isempty(cand)
-    fprintf('ea_ensure_b0_coreg: No preprocessed T1 found in %s, skipping.\n', anatDir);
+anatPath = fullfile(directory, anatRel);
+if ~isfile(anatPath)
+    fprintf('ea_ensure_b0_coreg: Anatomical file missing (%s), skipping.\n', anatPath);
     return;
 end
-anatPath = fullfile(cand(1).folder, cand(1).name);
 
 % Derive short names for pattern matching
 [~, b0Name] = fileparts(b0Path);
-[~, anatName] = fileparts(anatPath);
 b0Name  = regexprep(b0Name, '\.nii(\.gz)?$', '');
 anatName = regexprep(anatName, '\.nii(\.gz)?$', '');
 
-% Search for existing transform B0->T1
+% Search for existing transform B0->T1 (include preprocessing/dwi where SPM often writes)
 searchDirs = {
     fullfile(directory, 'coregistration', 'transformations')
     fullfile(directory, 'preprocessing', 'anat')
+    fullfile(directory, 'preprocessing', 'dwi')
     directory
 };
-pattern = [b0Name, '2', anatName]; % B0 -> T1
+fwdPrefix = [b0Name, '2', anatName, '_'];
+fwdAnts = [b0Name, '2', anatName, 'Composite'];
 for iDir = 1:numel(searchDirs)
     cdir = searchDirs{iDir};
     if ~isfolder(cdir), continue; end
-    mfiles = dir(fullfile(cdir, '*.mat'));
+    mfiles = [dir(fullfile(cdir, '*.mat')); dir(fullfile(cdir, '*.h5')); dir(fullfile(cdir, '*Composite*.nii.gz'))];
     for k = 1:numel(mfiles)
-        if contains(mfiles(k).name, pattern)
-            fprintf('ea_ensure_b0_coreg: Found existing B0->T1 transform: %s (in %s)\n', ...
-                mfiles(k).name, cdir);
+        nm = mfiles(k).name;
+        if startsWith(nm, fwdAnts)
+            fprintf('ea_ensure_b0_coreg: Found existing B0->T1 transform: %s (in %s)\n', nm, cdir);
+            return;
+        end
+        if startsWith(nm, fwdPrefix) && ~contains(nm, '_seg8') && ...
+                (contains(nm, '_spm') || contains(lower(nm), 'ants') || contains(nm, 'Composite') || endsWith(nm, '.h5'))
+            fprintf('ea_ensure_b0_coreg: Found existing B0->T1 transform: %s (in %s)\n', nm, cdir);
             return;
         end
     end
@@ -77,7 +78,8 @@ end
 fprintf('ea_ensure_b0_coreg: No B0->T1 transform found. Running coregistration now...\n');
 
 % Build output filename in preprocessing/anat
-outName = sprintf('%s2%s_%s.mat', b0Name, anatName, lower(regexp(options.coregmr.method, '^[^\s\(]+', 'match', 'once')));
+methodTok = regexp(options.coregmr.method, '^[^\s\(]+', 'match', 'once');
+if isempty(methodTok), methodTok = 'spm'; end
 outDir  = fullfile(directory, 'preprocessing', 'anat');
 if ~isfolder(outDir), outDir = directory; end
 ofile   = fullfile(outDir, [b0Name, '2', anatName, '.nii']);
@@ -92,4 +94,3 @@ try
 catch ME
     warning('ea_ensure_b0_coreg: Coregistration B0->T1 failed: %s', ME.message);
 end
-

--- a/connectomics/ea_ensure_fa_and_fa2anat.m
+++ b/connectomics/ea_ensure_fa_and_fa2anat.m
@@ -55,21 +55,15 @@ if isfile(fa2anatPath)
     return;
 end
 
-% Anatomical reference
-anatPath = fullfile(directory, options.prefs.prenii_unnormalized);
-if ~isfile(anatPath)
-    % Try preprocessing/anat or coregistration/anat
-    for subdir = {'preprocessing/anat', 'coregistration/anat'}
-        d = dir(fullfile(directory, subdir{1}, '*T1w.nii'));
-        if isempty(d), d = dir(fullfile(directory, subdir{1}, '*T2w.nii')); end
-        if ~isempty(d)
-            anatPath = fullfile(d(1).folder, d(1).name);
-            break;
-        end
-    end
-end
-if ~isfile(anatPath)
+% Anatomical reference (LC-only resolver; ignores SPM/coreg intermediates)
+[options, anatRel] = ea_lc_resolve_anat_anchor(options);
+if isempty(anatRel)
     warning('ea_ensure_fa_and_fa2anat: Anatomical reference not found. Skipping FA->anat coregistration.');
+    return;
+end
+anatPath = fullfile(directory, anatRel);
+if ~isfile(anatPath)
+    warning('ea_ensure_fa_and_fa2anat: Anatomical reference not found (%s). Skipping FA->anat coregistration.', anatPath);
     return;
 end
 

--- a/connectomics/ea_lc_resolve_anat_anchor.m
+++ b/connectomics/ea_lc_resolve_anat_anchor.m
@@ -1,0 +1,219 @@
+function [options, anatRel, anatName] = ea_lc_resolve_anat_anchor(options)
+% EA_LC_RESOLVE_ANAT_ANCHOR  Resolve anatomical anchor for Lead-Connectome only.
+%
+% Finds the real T1/T2 anatomical image for DWI<->anat coregistration and
+% fiber normalization, ignoring SPM/coreg intermediate products that often
+% pollute preprocessing/anat (c1*/w*/b02*/dwi* nested names).
+%
+% Preference order:
+%   1. coregistration/anat space-anchorNative preproc T1/T2
+%   2. preprocessing/anat desc-preproc T1/T2 (filtered)
+%   3. existing prefs.prenii_unnormalized if it passes the filter
+% Among valid candidates, prefer one that already has a B0->anat transform
+% on disk (avoids unnecessary re-coreg when preprocessing anat was used).
+%
+% Does NOT modify ea_getptopts or any global prefs files. Only updates the
+% in-memory options.prefs.prenii_unnormalized for the current LC call.
+%
+% Outputs:
+%   options  - options with prenii_unnormalized corrected when a better
+%              anchor was found
+%   anatRel  - path relative to subject directory (or '' if unresolved)
+%   anatName - basename without .nii/.nii.gz (or '' if unresolved)
+
+directory = [options.root, options.patientname, filesep];
+anatRel = '';
+anatName = '';
+
+candidates = {}; % full paths, preference order
+
+% --- Priority 1: coregistration/anat anchorNative preproc ---
+coregAnatDir = fullfile(directory, 'coregistration', 'anat');
+candidates = [candidates, collect_valid(coregAnatDir, {
+    '*space-anchorNative*desc-preproc*T1w.nii'
+    '*space-anchorNative*T1w.nii'
+    '*space-anchorNative*desc-preproc*T2w.nii'
+    '*space-anchorNative*T2w.nii'
+})];
+
+% --- Priority 2: preprocessing/anat desc-preproc T1/T2 ---
+preprocAnatDir = fullfile(directory, 'preprocessing', 'anat');
+candidates = [candidates, collect_valid(preprocAnatDir, {
+    '*desc-preproc*_T1w.nii'
+    '*desc-preproc*_T2w.nii'
+    '*_T1w.nii'
+    '*_T2w.nii'
+})];
+
+% --- Priority 3: existing prefs.prenii_unnormalized if it passes filter ---
+if isfield(options, 'prefs') && isfield(options.prefs, 'prenii_unnormalized') ...
+        && ~isempty(options.prefs.prenii_unnormalized)
+    prefPath = fullfile(directory, options.prefs.prenii_unnormalized);
+    if isfile(prefPath)
+        [~, prefBase, prefExt] = fileparts(options.prefs.prenii_unnormalized);
+        if strcmpi(prefExt, '.gz')
+            [~, prefBase] = fileparts(prefBase);
+        end
+        if is_valid_anat_basename(prefBase)
+            candidates{end+1} = prefPath; %#ok<AGROW>
+        end
+    end
+end
+
+% Deduplicate while preserving order
+candidates = unique_preserve(candidates);
+
+if isempty(candidates)
+    fprintf('ea_lc_resolve_anat_anchor: No valid anatomical anchor found.\n');
+    return;
+end
+
+% Prefer candidate that already has a B0->anat transform (if b0 known)
+cand = candidates{1};
+b0Name = '';
+if isfield(options, 'prefs') && isfield(options.prefs, 'b0') && ~isempty(options.prefs.b0)
+    b0Path = fullfile(directory, options.prefs.b0);
+    if ~isfile(b0Path)
+        b0Dir = fullfile(directory, 'preprocessing', 'dwi');
+        d = dir(fullfile(b0Dir, '*_b0.nii'));
+        if isempty(d), d = dir(fullfile(b0Dir, '*b0*.nii')); end
+        if ~isempty(d)
+            b0Path = fullfile(d(1).folder, d(1).name);
+        end
+    end
+    if isfile(b0Path)
+        [~, b0Name] = fileparts(b0Path);
+        b0Name = regexprep(b0Name, '\.nii(\.gz)?$', '');
+    end
+end
+
+if ~isempty(b0Name)
+    for i = 1:numel(candidates)
+        [~, thisAnat] = fileparts(candidates{i});
+        thisAnat = regexprep(thisAnat, '\.nii(\.gz)?$', '');
+        if has_b0_to_anat_transform(directory, b0Name, thisAnat)
+            cand = candidates{i};
+            break;
+        end
+    end
+end
+
+% Relative path from subject root
+if startsWith(cand, directory)
+    anatRel = cand(length(directory)+1:end);
+else
+    anatRel = cand;
+end
+if filesep ~= '/'
+    anatRel = strrep(strrep(anatRel, '\', '/'), '/', filesep);
+else
+    anatRel = strrep(anatRel, '\', '/');
+end
+
+[~, anatName] = fileparts(anatRel);
+anatName = regexprep(anatName, '\.nii(\.gz)?$', '');
+
+% In-memory correction for this LC run only
+prev = '';
+if isfield(options, 'prefs') && isfield(options.prefs, 'prenii_unnormalized')
+    prev = options.prefs.prenii_unnormalized;
+end
+options.prefs.prenii_unnormalized = anatRel;
+
+if ~strcmp(prev, anatRel)
+    fprintf('ea_lc_resolve_anat_anchor: Using anatomical anchor: %s\n', anatRel);
+    if ~isempty(prev)
+        fprintf('  (prefs.prenii_unnormalized was: %s)\n', prev);
+    end
+end
+
+
+function paths = collect_valid(searchDir, patterns)
+paths = {};
+if ~isfolder(searchDir)
+    return;
+end
+for p = 1:numel(patterns)
+    hits = dir(fullfile(searchDir, patterns{p}));
+    for k = 1:numel(hits)
+        if hits(k).isdir
+            continue;
+        end
+        [~, base, ext] = fileparts(hits(k).name);
+        if strcmpi(ext, '.gz')
+            [~, base] = fileparts(base);
+        end
+        if is_valid_anat_basename(base)
+            paths{end+1} = fullfile(hits(k).folder, hits(k).name); %#ok<AGROW>
+        end
+    end
+end
+
+
+function out = unique_preserve(in)
+out = {};
+for i = 1:numel(in)
+    if ~any(strcmp(out, in{i}))
+        out{end+1} = in{i}; %#ok<AGROW>
+    end
+end
+
+
+function tf = has_b0_to_anat_transform(directory, b0Name, anatName)
+tf = false;
+% Forward coreg mats start with b0Name2anatName_ and carry a method token
+% (e.g. _spm). Exclude SPM segmentation sidecars (*_seg8.mat).
+fwdPrefix = [b0Name, '2', anatName, '_'];
+fwdAnts = [b0Name, '2', anatName, 'Composite'];
+searchDirs = {
+    fullfile(directory, 'preprocessing', 'anat')
+    fullfile(directory, 'preprocessing', 'dwi')
+    fullfile(directory, 'coregistration', 'transformations')
+    directory
+};
+for iDir = 1:numel(searchDirs)
+    cdir = searchDirs{iDir};
+    if ~isfolder(cdir), continue; end
+    mfiles = [dir(fullfile(cdir, '*.mat')); dir(fullfile(cdir, '*.h5')); dir(fullfile(cdir, '*Composite*.nii.gz'))];
+    for k = 1:numel(mfiles)
+        nm = mfiles(k).name;
+        if startsWith(nm, fwdAnts)
+            tf = true;
+            return;
+        end
+        if startsWith(nm, fwdPrefix) && ~contains(nm, '_seg8') && ...
+                (contains(nm, '_spm') || contains(lower(nm), 'ants') || contains(nm, 'Composite') || endsWith(nm, '.h5'))
+            tf = true;
+            return;
+        end
+    end
+end
+
+
+function tf = is_valid_anat_basename(base)
+% Reject SPM tissue classes, warped outputs, and moving2fixed intermediates.
+tf = false;
+if isempty(base)
+    return;
+end
+
+% Prefix filters (c1/c2/c3, w, r, sr, mean)
+if ~isempty(regexp(base, '^(c[1-3]|w|r|sr|mean)', 'once'))
+    return;
+end
+
+% Coreg / DWI intermediate products (b02..., ...2c1..., ...2sub-...)
+if contains(base, 'dwi', 'IgnoreCase', true)
+    return;
+end
+if contains(base, 'b02')
+    return;
+end
+if contains(base, '2c1') || contains(base, '2c2') || contains(base, '2c3')
+    return;
+end
+if contains(base, '2sub-')
+    return;
+end
+
+tf = true;

--- a/connectomics/ea_normalize_fibers.m
+++ b/connectomics/ea_normalize_fibers.m
@@ -138,18 +138,32 @@ fprintf('\nNormalizing fibers...\n');
 
 %% map from b0 voxel space to anat mm and voxel space
 fprintf('\nMapping from b0 to anat...\n');
+
+% LC-only: resolve real anatomical anchor (ignore SPM/coreg intermediates)
+prefsAnatBefore = '';
+if isfield(options.prefs, 'prenii_unnormalized')
+    prefsAnatBefore = options.prefs.prenii_unnormalized;
+end
+[options, ~, anatNameResolved] = ea_lc_resolve_anat_anchor(options);
+if isempty(anatNameResolved)
+    ea_error('Anatomical anchor not found for fiber normalization. Please ensure a preprocessed T1/T2 exists.');
+end
+
 [~, mov] = fileparts(options.prefs.b0);
 [~, fix] = fileparts(options.prefs.prenii_unnormalized);
+[~, b0Name] = ea_niifileparts(options.prefs.b0);
+anatName = anatNameResolved;
+
+searchDirs = {
+    fullfile(directory, 'preprocessing', 'anat')
+    fullfile(directory, 'preprocessing', 'dwi')
+    fullfile(directory, 'coregistration', 'transformations')
+    directory
+};
 
 % For BIDS: search in coregistration/transformations and preprocessing dirs
 if strcmp(options.coregmr.method, 'ANTs') && options.coregb0.addSyN
     % BIDS FIX: Use dir() instead of ea_regexpdir for ANTs files
-    searchDirs = {
-        fullfile(directory, 'coregistration', 'transformations')
-        fullfile(directory, 'preprocessing', 'anat')
-        directory
-    };
-    
     transform = {};
     for iDir = 1:length(searchDirs)
         if exist(searchDirs{iDir}, 'dir')
@@ -175,31 +189,52 @@ else
     end
     options.coregmr.method = coregmethod;
     
-    % BIDS FIX: Use simpler search with dir() instead of ea_regexpdir
-    % Search for b0→anat transformation file
-    [~, b0Name] = ea_niifileparts(options.prefs.b0);
-    [~, anatName] = ea_niifileparts(options.prefs.prenii_unnormalized);
-    
     fprintf('DEBUG ea_normalize_fibers: Searching for transformation...\n');
     fprintf('  b0Name: %s\n', b0Name);
-    fprintf('  anatName: %s\n', anatName);
+    fprintf('  anatName (resolved): %s\n', anatName);
+    if ~isempty(prefsAnatBefore)
+        fprintf('  prefs.prenii_unnormalized (before resolve): %s\n', prefsAnatBefore);
+    end
     fprintf('  coregmethod: %s\n', lower(coregmethod));
     
-    % Try preprocessing/anat first
-    searchDirs = {fullfile(directory, 'preprocessing', 'anat'), directory};
     transform = {};
+    patternExact = [b0Name, '2', anatName, '_', lower(coregmethod), '*.mat'];
     
     for iDir = 1:length(searchDirs)
-        if exist(searchDirs{iDir}, 'dir')
-            % Search for files matching pattern: b0Name2anatName_method.mat
-            pattern = [b0Name, '2', anatName, '_', lower(coregmethod), '*.mat'];
-            fprintf('  Searching in: %s\n', searchDirs{iDir});
-            fprintf('  Pattern: %s\n', pattern);
-            files = dir(fullfile(searchDirs{iDir}, pattern));
-            fprintf('  Found %d files\n', length(files));
-            if ~isempty(files)
-                transform = {fullfile(searchDirs{iDir}, files(end).name)};
-                fprintf('  Using: %s\n', transform{1});
+        if ~exist(searchDirs{iDir}, 'dir')
+            continue;
+        end
+        fprintf('  Searching in: %s\n', searchDirs{iDir});
+        fprintf('  Pattern: %s\n', patternExact);
+        files = dir(fullfile(searchDirs{iDir}, patternExact));
+        fprintf('  Found %d files\n', length(files));
+        if ~isempty(files)
+            transform = {fullfile(searchDirs{iDir}, files(end).name)};
+            fprintf('  Using: %s\n', transform{1});
+            break;
+        end
+    end
+    
+    % Fallback: forward mats starting with b0Name2anatName_ + method token
+    if isempty(transform)
+        fprintf('  Exact pattern missed; trying fallback prefix-search...\n');
+        fwdPrefix = [b0Name, '2', anatName, '_'];
+        for iDir = 1:length(searchDirs)
+            if ~exist(searchDirs{iDir}, 'dir')
+                continue;
+            end
+            files = dir(fullfile(searchDirs{iDir}, '*.mat'));
+            hits = {};
+            for iFile = 1:length(files)
+                nm = files(iFile).name;
+                if startsWith(nm, fwdPrefix) && ~contains(nm, '_seg8') && ...
+                        (contains(nm, ['_', lower(coregmethod)]) || contains(nm, 'Composite'))
+                    hits{end+1} = fullfile(searchDirs{iDir}, nm); %#ok<AGROW>
+                end
+            end
+            if ~isempty(hits)
+                transform = hits(end);
+                fprintf('  Fallback using: %s\n', transform{1});
                 break;
             end
         end
@@ -211,6 +246,13 @@ if isempty(transform)
     fprintf('Available files in preprocessing/anat:\n');
     if exist(fullfile(directory, 'preprocessing', 'anat'), 'dir')
         allFiles = dir(fullfile(directory, 'preprocessing', 'anat', '*.mat'));
+        for i = 1:length(allFiles)
+            fprintf('  %s\n', allFiles(i).name);
+        end
+    end
+    fprintf('Available files in preprocessing/dwi:\n');
+    if exist(fullfile(directory, 'preprocessing', 'dwi'), 'dir')
+        allFiles = dir(fullfile(directory, 'preprocessing', 'dwi', '*.mat'));
         for i = 1:length(allFiles)
             fprintf('  %s\n', allFiles(i).name);
         end

--- a/connectomics/ea_perform_lc.m
+++ b/connectomics/ea_perform_lc.m
@@ -16,6 +16,8 @@ if contains(directory, 'derivatives') || contains(directory, 'leaddbs')
         warning('Could not load BIDS paths via ea_getptopts, attempting manual path construction');
     end
 end
+% LC-only: correct anatomical anchor in-memory (do not change ea_getptopts)
+options = ea_lc_resolve_anat_anchor(options);
 
 %% structural parts
 disp('*** Performing structural parts of LEAD-Connectome...');
@@ -35,6 +37,8 @@ if options.lc.struc.ft.normalize % normalize fibertracts ? for now these should 
             warning('Could not refresh BIDS paths before normalization');
         end
     end
+    % LC-only: re-resolve anatomical anchor after getptopts refresh
+    options = ea_lc_resolve_anat_anchor(options);
     ea_normalize_fibers(options);
 end
 
@@ -62,6 +66,8 @@ if options.lc.struc.compute_CM
                     warning('Could not refresh BIDS paths after fiber tracking');
                 end
             end
+            % LC-only: re-resolve anatomical anchor after getptopts refresh
+            options = ea_lc_resolve_anat_anchor(options);
         end
         DTI_CM=ea_createCM_dti(options);
         cm=ea_export_CM_png(DTI_CM,'DTI Connectivity matrix',options,[0 mean(DTI_CM(:))+2*std(DTI_CM(:))]);


### PR DESCRIPTION
## Summary
- Fixes Lead-Connectome fiber normalization failing with `Coregistration transformation not found` when `preprocessing/anat` contains SPM/coreg intermediates (`c1*`, `b02*`, nested `moving2fixed` names).
- Adds LC-only helper `ea_lc_resolve_anat_anchor` to pick the real anatomical anchor and prefer candidates that already have a B0→anat transform.
- Updates `ea_ensure_b0_coreg`, `ea_ensure_fa_and_fa2anat`, `ea_normalize_fibers`, and `ea_perform_lc` to use this resolver and also search `preprocessing/dwi` for transforms.
- Leaves `ea_getptopts` and non-connectomics Lead-DBS paths unchanged.
